### PR TITLE
feat: build webhook testing UI to create, send, and verify test payloads

### DIFF
--- a/admin/app/page.tsx
+++ b/admin/app/page.tsx
@@ -35,6 +35,19 @@ export default function Home() {
             />
             API Explorer
           </Link>
+          <Link
+            className="flex h-12 w-full items-center justify-center gap-2 rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
+            href="/webhook-tester"
+          >
+            <Image
+              className="dark:invert"
+              src="/file.svg"
+              alt="Webhook Tester"
+              width={16}
+              height={16}
+            />
+            Webhook Tester
+          </Link>
           <a
             className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
             href="/admin"

--- a/admin/app/webhook-tester/components/HistoryPanel.tsx
+++ b/admin/app/webhook-tester/components/HistoryPanel.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useWebhookTester } from '../context';
+import type { HistoryEntry } from '../types';
+
+function statusColor(entry: HistoryEntry) {
+  if (entry.error) return 'text-red-400';
+  if (entry.response && entry.response.status >= 200 && entry.response.status < 300)
+    return 'text-green-400';
+  if (entry.response) return 'text-orange-400';
+  return 'text-zinc-400';
+}
+
+function statusLabel(entry: HistoryEntry) {
+  if (entry.error) return 'ERR';
+  if (entry.response) return String(entry.response.status);
+  return '---';
+}
+
+export function HistoryPanel() {
+  const { history, clearHistory, selectHistoryEntry } = useWebhookTester();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div
+      className={`absolute bottom-0 left-0 right-0 bg-zinc-900 border-t border-zinc-800 transition-all duration-200 ${
+        isOpen ? 'h-56' : 'h-9'
+      }`}
+    >
+      {/* Toggle bar */}
+      <div
+        className="flex items-center justify-between px-4 h-9 cursor-pointer select-none"
+        onClick={() => setIsOpen((o) => !o)}
+      >
+        <div className="flex items-center gap-2">
+          <svg
+            className={`w-3.5 h-3.5 text-zinc-500 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+          </svg>
+          <span className="text-xs font-semibold uppercase tracking-widest text-zinc-400">
+            History
+          </span>
+          {history.length > 0 && (
+            <span className="text-xs bg-zinc-700 text-zinc-300 px-1.5 py-0.5 rounded-full">
+              {history.length}
+            </span>
+          )}
+        </div>
+        {isOpen && history.length > 0 && (
+          <button
+            onClick={(e) => { e.stopPropagation(); clearHistory(); }}
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Entries */}
+      {isOpen && (
+        <div className="overflow-y-auto h-[calc(100%-2.25rem)]">
+          {history.length === 0 ? (
+            <div className="px-4 py-6 text-center text-xs text-zinc-600 font-mono">
+              no history yet
+            </div>
+          ) : (
+            history.map((entry) => (
+              <button
+                key={entry.id}
+                onClick={() => selectHistoryEntry(entry)}
+                className="w-full flex items-center gap-3 px-4 py-2 hover:bg-zinc-800/60 transition-colors border-b border-zinc-800/40 text-left"
+              >
+                <span className={`font-mono text-xs font-semibold w-8 flex-shrink-0 ${statusColor(entry)}`}>
+                  {statusLabel(entry)}
+                </span>
+                <span className="text-xs font-mono text-zinc-400 truncate flex-1">
+                  {entry.targetUrl}
+                </span>
+                <span className="text-xs text-zinc-600 flex-shrink-0">
+                  {entry.timestamp.toLocaleTimeString()}
+                </span>
+                {entry.response && (
+                  <span className="text-xs text-zinc-600 flex-shrink-0">
+                    {entry.response.time}ms
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/app/webhook-tester/components/PayloadEditor.tsx
+++ b/admin/app/webhook-tester/components/PayloadEditor.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { useWebhookTester } from '../context';
+import { DEFAULT_PAYLOAD } from '../types';
+
+// Minimal syntax highlighting for JSON in a textarea overlay approach
+function highlight(json: string): string {
+  return json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(
+      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
+      (match) => {
+        if (/^"/.test(match)) {
+          if (/:$/.test(match)) return `<span class="text-blue-400">${match}</span>`;
+          return `<span class="text-green-400">${match}</span>`;
+        }
+        if (/true|false/.test(match)) return `<span class="text-yellow-400">${match}</span>`;
+        if (/null/.test(match)) return `<span class="text-zinc-500">${match}</span>`;
+        return `<span class="text-orange-400">${match}</span>`;
+      }
+    );
+}
+
+export function PayloadEditor() {
+  const {
+    selectedWebhook,
+    payload,
+    setPayload,
+    payloadError,
+    isSending,
+    sendTest,
+  } = useWebhookTester();
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleFormat = () => {
+    try {
+      setPayload(JSON.stringify(JSON.parse(payload), null, 2));
+    } catch {
+      // invalid JSON, leave as-is
+    }
+  };
+
+  const handleReset = () => {
+    setPayload(DEFAULT_PAYLOAD);
+  };
+
+  // Sync scroll between textarea and highlight overlay
+  const handleScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
+    const pre = e.currentTarget.previousElementSibling as HTMLElement | null;
+    if (pre) {
+      pre.scrollTop = e.currentTarget.scrollTop;
+      pre.scrollLeft = e.currentTarget.scrollLeft;
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-800 bg-zinc-900">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-widest text-zinc-400">
+            Payload
+          </span>
+          {payloadError && (
+            <span className="text-xs text-red-400 font-mono truncate max-w-xs">
+              ✗ {payloadError}
+            </span>
+          )}
+          {!payloadError && payload.trim() && (
+            <span className="text-xs text-green-400">✓ valid JSON</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleFormat}
+            className="text-xs px-2 py-1 rounded bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors"
+          >
+            Format
+          </button>
+          <button
+            onClick={handleReset}
+            className="text-xs px-2 py-1 rounded bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Terminal-style editor */}
+      <div className="flex-1 relative overflow-hidden bg-zinc-950 font-mono text-sm">
+        {/* Syntax-highlighted backdrop */}
+        <pre
+          aria-hidden="true"
+          className="absolute inset-0 p-4 overflow-auto pointer-events-none whitespace-pre text-zinc-300 leading-6"
+          dangerouslySetInnerHTML={{ __html: highlight(payload) }}
+        />
+        {/* Actual editable textarea (transparent text, caret visible) */}
+        <textarea
+          ref={textareaRef}
+          value={payload}
+          onChange={(e) => setPayload(e.target.value)}
+          onScroll={handleScroll}
+          spellCheck={false}
+          className="absolute inset-0 w-full h-full p-4 bg-transparent text-transparent caret-zinc-200 resize-none outline-none leading-6 font-mono text-sm"
+        />
+      </div>
+
+      {/* Send button */}
+      <div className="px-4 py-3 border-t border-zinc-800 bg-zinc-900 flex items-center gap-3">
+        {selectedWebhook && (
+          <div className="flex-1 min-w-0">
+            <span className="text-xs text-zinc-500">Target: </span>
+            <span className="text-xs font-mono text-zinc-300 truncate">{selectedWebhook.target_url}</span>
+          </div>
+        )}
+        <button
+          onClick={sendTest}
+          disabled={!selectedWebhook || isSending || !!payloadError}
+          className="flex items-center gap-2 px-4 py-2 rounded bg-blue-600 text-white text-sm font-medium
+            hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex-shrink-0"
+        >
+          {isSending ? (
+            <>
+              <div className="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              Sending…
+            </>
+          ) : (
+            <>
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              Send Test
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/admin/app/webhook-tester/components/ResponseViewer.tsx
+++ b/admin/app/webhook-tester/components/ResponseViewer.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useWebhookTester } from '../context';
+
+type Tab = 'body' | 'headers';
+
+function statusColor(status: number) {
+  if (status >= 200 && status < 300) return 'text-green-400';
+  if (status >= 300 && status < 400) return 'text-amber-400';
+  if (status >= 400 && status < 500) return 'text-orange-400';
+  return 'text-red-400';
+}
+
+export function ResponseViewer() {
+  const { response, sendError, isSending } = useWebhookTester();
+  const [tab, setTab] = useState<Tab>('body');
+
+  if (isSending) {
+    return (
+      <div className="flex items-center justify-center h-full bg-zinc-950">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-7 h-7 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm text-zinc-400 font-mono">dispatching…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (sendError) {
+    return (
+      <div className="p-4 bg-zinc-950 h-full">
+        <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-lg font-mono text-sm">
+          <span className="text-red-400">✗ {sendError}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!response) {
+    return (
+      <div className="flex items-center justify-center h-full bg-zinc-950">
+        <div className="text-center">
+          <div className="w-12 h-12 mx-auto mb-3 bg-zinc-800 rounded-full flex items-center justify-center">
+            <svg className="w-6 h-6 text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <p className="text-sm text-zinc-500 font-mono">awaiting response</p>
+        </div>
+      </div>
+    );
+  }
+
+  const bodyStr =
+    typeof response.body === 'string'
+      ? response.body
+      : JSON.stringify(response.body, null, 2);
+
+  return (
+    <div className="flex flex-col h-full bg-zinc-950">
+      {/* Status bar */}
+      <div className="flex items-center gap-4 px-4 py-2 border-b border-zinc-800 bg-zinc-900 font-mono text-xs">
+        <span className="text-zinc-500">HTTP</span>
+        <span className={`font-semibold ${statusColor(response.status)}`}>
+          {response.status} {response.statusText}
+        </span>
+        <span className="text-zinc-600">|</span>
+        <span className="text-zinc-400">{response.time}ms</span>
+        <span className="text-zinc-600">|</span>
+        <span className="text-zinc-400">{new Blob([bodyStr]).size}B</span>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-zinc-800">
+        {(['body', 'headers'] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-xs font-medium border-b-2 transition-colors capitalize ${
+              tab === t
+                ? 'border-blue-500 text-zinc-100'
+                : 'border-transparent text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            {t}
+            {t === 'headers' && ` (${Object.keys(response.headers).length})`}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-4">
+        {tab === 'body' ? (
+          <pre className="text-xs text-zinc-300 font-mono whitespace-pre-wrap leading-5">
+            {bodyStr}
+          </pre>
+        ) : (
+          <div className="space-y-1.5">
+            {Object.entries(response.headers).map(([k, v]) => (
+              <div key={k} className="flex gap-3 font-mono text-xs">
+                <span className="text-blue-400 min-w-[180px] flex-shrink-0">{k}</span>
+                <span className="text-zinc-300">{v}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin/app/webhook-tester/components/WebhookSelector.tsx
+++ b/admin/app/webhook-tester/components/WebhookSelector.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React from 'react';
+import { useWebhookTester } from '../context';
+
+export function WebhookSelector() {
+  const { webhooks, isLoadingWebhooks, selectedWebhook, setSelectedWebhook, fetchWebhooks } =
+    useWebhookTester();
+
+  return (
+    <div className="flex flex-col h-full bg-zinc-900 border-r border-zinc-800">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+        <span className="text-xs font-semibold uppercase tracking-widest text-zinc-400">
+          Webhooks
+        </span>
+        <button
+          onClick={fetchWebhooks}
+          disabled={isLoadingWebhooks}
+          className="p-1 rounded text-zinc-500 hover:text-zinc-200 transition-colors"
+          title="Refresh"
+        >
+          <svg
+            className={`w-4 h-4 ${isLoadingWebhooks ? 'animate-spin' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoadingWebhooks ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : webhooks.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-zinc-500">
+            No webhooks found
+          </div>
+        ) : (
+          webhooks.map((wh) => {
+            const isSelected = selectedWebhook?.id === wh.id;
+            return (
+              <button
+                key={wh.id}
+                onClick={() => setSelectedWebhook(wh)}
+                className={`w-full text-left px-4 py-3 border-b border-zinc-800/50 transition-colors ${
+                  isSelected
+                    ? 'bg-blue-500/10 border-l-2 border-l-blue-500'
+                    : 'hover:bg-zinc-800/50 border-l-2 border-l-transparent'
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <span
+                    className={`inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                      wh.status === 'active' ? 'bg-green-400' : 'bg-yellow-400'
+                    }`}
+                  />
+                  <span className="text-xs font-mono text-zinc-300 truncate">
+                    #{wh.id}
+                  </span>
+                  {wh.event_type && (
+                    <span className="text-xs bg-zinc-700 text-zinc-300 px-1.5 py-0.5 rounded truncate max-w-[80px]">
+                      {wh.event_type}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-zinc-400 truncate font-mono">
+                  {wh.target_url}
+                </div>
+                <div className="text-xs text-zinc-600 truncate mt-0.5">
+                  {wh.contract_id}
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin/app/webhook-tester/context.tsx
+++ b/admin/app/webhook-tester/context.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react';
+import type { WebhookSubscription, TestResponse, HistoryEntry } from './types';
+import { DEFAULT_PAYLOAD } from './types';
+
+const BASE_URL = 'http://localhost:8000';
+
+interface WebhookTesterContextType {
+  // Webhooks list
+  webhooks: WebhookSubscription[];
+  isLoadingWebhooks: boolean;
+  fetchWebhooks: () => Promise<void>;
+
+  // Selected webhook
+  selectedWebhook: WebhookSubscription | null;
+  setSelectedWebhook: (w: WebhookSubscription | null) => void;
+
+  // Payload editor
+  payload: string;
+  setPayload: (p: string) => void;
+  payloadError: string | null;
+
+  // Send
+  isSending: boolean;
+  sendTest: () => Promise<void>;
+
+  // Response
+  response: TestResponse | null;
+  sendError: string | null;
+
+  // History
+  history: HistoryEntry[];
+  clearHistory: () => void;
+  selectHistoryEntry: (entry: HistoryEntry) => void;
+}
+
+const WebhookTesterContext = createContext<WebhookTesterContextType | undefined>(undefined);
+
+export function WebhookTesterProvider({ children }: { children: ReactNode }) {
+  const [webhooks, setWebhooks] = useState<WebhookSubscription[]>([]);
+  const [isLoadingWebhooks, setIsLoadingWebhooks] = useState(false);
+  const [selectedWebhook, setSelectedWebhookState] = useState<WebhookSubscription | null>(null);
+  const [payload, setPayloadState] = useState(DEFAULT_PAYLOAD);
+  const [payloadError, setPayloadError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [response, setResponse] = useState<TestResponse | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+
+  const fetchWebhooks = useCallback(async () => {
+    setIsLoadingWebhooks(true);
+    try {
+      const res = await fetch(`${BASE_URL}/api/ingest/webhooks/?page_size=100`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setWebhooks(data.results ?? data);
+    } catch {
+      setWebhooks([]);
+    } finally {
+      setIsLoadingWebhooks(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchWebhooks();
+  }, [fetchWebhooks]);
+
+  const setSelectedWebhook = useCallback((w: WebhookSubscription | null) => {
+    setSelectedWebhookState(w);
+    setResponse(null);
+    setSendError(null);
+    if (w) {
+      // Pre-fill contract_id in payload
+      try {
+        const parsed = JSON.parse(payload);
+        parsed.contract_id = w.contract_id;
+        if (w.event_type) parsed.event_type = w.event_type;
+        setPayloadState(JSON.stringify(parsed, null, 2));
+      } catch {
+        // keep existing payload
+      }
+    }
+  }, [payload]);
+
+  const setPayload = useCallback((p: string) => {
+    setPayloadState(p);
+    try {
+      JSON.parse(p);
+      setPayloadError(null);
+    } catch (e) {
+      setPayloadError(e instanceof Error ? e.message : 'Invalid JSON');
+    }
+  }, []);
+
+  const sendTest = useCallback(async () => {
+    if (!selectedWebhook) return;
+
+    // Validate JSON
+    let parsedPayload: unknown;
+    try {
+      parsedPayload = JSON.parse(payload);
+    } catch (e) {
+      setPayloadError(e instanceof Error ? e.message : 'Invalid JSON');
+      return;
+    }
+
+    setIsSending(true);
+    setResponse(null);
+    setSendError(null);
+
+    const start = performance.now();
+
+    try {
+      const res = await fetch(
+        `${BASE_URL}/api/ingest/webhooks/${selectedWebhook.id}/test/`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(parsedPayload),
+        }
+      );
+
+      const elapsed = Math.round(performance.now() - start);
+      const responseHeaders: Record<string, string> = {};
+      res.headers.forEach((v, k) => { responseHeaders[k] = v; });
+
+      let body: unknown;
+      const ct = res.headers.get('content-type') ?? '';
+      body = ct.includes('application/json') ? await res.json() : await res.text();
+
+      const testResponse: TestResponse = {
+        status: res.status,
+        statusText: res.statusText,
+        headers: responseHeaders,
+        body,
+        time: elapsed,
+      };
+
+      setResponse(testResponse);
+
+      const entry: HistoryEntry = {
+        id: crypto.randomUUID(),
+        timestamp: new Date(),
+        webhookId: selectedWebhook.id,
+        targetUrl: selectedWebhook.target_url,
+        payload,
+        response: testResponse,
+      };
+      setHistory(prev => [entry, ...prev].slice(0, 50));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Network error';
+      setSendError(msg);
+      const entry: HistoryEntry = {
+        id: crypto.randomUUID(),
+        timestamp: new Date(),
+        webhookId: selectedWebhook.id,
+        targetUrl: selectedWebhook.target_url,
+        payload,
+        error: msg,
+      };
+      setHistory(prev => [entry, ...prev].slice(0, 50));
+    } finally {
+      setIsSending(false);
+    }
+  }, [selectedWebhook, payload]);
+
+  const clearHistory = useCallback(() => setHistory([]), []);
+
+  const selectHistoryEntry = useCallback((entry: HistoryEntry) => {
+    setPayloadState(entry.payload);
+    setPayloadError(null);
+    setResponse(entry.response ?? null);
+    setSendError(entry.error ?? null);
+    const wh = webhooks.find(w => w.id === entry.webhookId);
+    if (wh) setSelectedWebhookState(wh);
+  }, [webhooks]);
+
+  return (
+    <WebhookTesterContext.Provider value={{
+      webhooks, isLoadingWebhooks, fetchWebhooks,
+      selectedWebhook, setSelectedWebhook,
+      payload, setPayload, payloadError,
+      isSending, sendTest,
+      response, sendError,
+      history, clearHistory, selectHistoryEntry,
+    }}>
+      {children}
+    </WebhookTesterContext.Provider>
+  );
+}
+
+export function useWebhookTester() {
+  const ctx = useContext(WebhookTesterContext);
+  if (!ctx) throw new Error('useWebhookTester must be used within WebhookTesterProvider');
+  return ctx;
+}

--- a/admin/app/webhook-tester/page.tsx
+++ b/admin/app/webhook-tester/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { WebhookTesterProvider } from './context';
+import { WebhookSelector } from './components/WebhookSelector';
+import { PayloadEditor } from './components/PayloadEditor';
+import { ResponseViewer } from './components/ResponseViewer';
+import { HistoryPanel } from './components/HistoryPanel';
+
+export default function WebhookTesterPage() {
+  return (
+    <WebhookTesterProvider>
+      <div className="flex h-screen bg-zinc-950 overflow-hidden">
+        {/* Sidebar: webhook selector */}
+        <div className="w-64 flex-shrink-0">
+          <WebhookSelector />
+        </div>
+
+        {/* Main: editor + response stacked, history drawer at bottom */}
+        <div className="flex-1 flex flex-col min-w-0 relative">
+          {/* Top half: payload editor */}
+          <div className="h-1/2 border-b border-zinc-800 overflow-hidden">
+            <PayloadEditor />
+          </div>
+
+          {/* Bottom half: response viewer */}
+          <div className="h-1/2 overflow-hidden">
+            <ResponseViewer />
+          </div>
+
+          {/* History drawer (absolute, overlays bottom) */}
+          <HistoryPanel />
+        </div>
+      </div>
+    </WebhookTesterProvider>
+  );
+}

--- a/admin/app/webhook-tester/types.ts
+++ b/admin/app/webhook-tester/types.ts
@@ -1,0 +1,42 @@
+// Webhook Tester Types
+
+export interface WebhookSubscription {
+  id: number;
+  contract_id: string;
+  event_type: string;
+  target_url: string;
+  is_active: boolean;
+  status: 'active' | 'suspended';
+  created_at: string;
+  last_triggered: string | null;
+  failure_count: number;
+}
+
+export interface TestResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: unknown;
+  time: number;
+}
+
+export interface HistoryEntry {
+  id: string;
+  timestamp: Date;
+  webhookId: number;
+  targetUrl: string;
+  payload: string;
+  response?: TestResponse;
+  error?: string;
+}
+
+export const DEFAULT_PAYLOAD = JSON.stringify(
+  {
+    event_type: 'test',
+    payload: { message: 'This is a test webhook' },
+    contract_id: '',
+    timestamp: new Date().toISOString(),
+  },
+  null,
+  2
+);


### PR DESCRIPTION
Closes #146

---

i Built a webhook testing console at /webhook-tester in the Next.js admin app. It lets you pick an existing webhook subscription, edit a JSON payload in a terminal-style syntax-highlighted editor, fire a test POST to the backend's /api/ingest/webhooks/{id}/test/ endpoint, and view the HTTP response (status, headers, body). Recent sends are tracked in a collapsible history drawer at the bottom. Then committed and pushed everything to the feature branch.