### PR TITLE
feat: update export_events args to match #167 spec

### DIFF
--- a/django-backend/soroscan/ingest/management/commands/export_events.py
+++ b/django-backend/soroscan/ingest/management/commands/export_events.py
@@ -5,10 +5,11 @@ Streams ContractEvent rows to Parquet, CSV, JSON, or Avro without loading
 all events into memory.
 
 Usage examples:
-    python manage.py export_events --contract-id CXXX --format json --output events.json
+    python manage.py export_events --contract CXXX --format json --output events.json
     python manage.py export_events --contract-id CXXX --format parquet --output events.parquet \
-        --start-ledger 1000000 --end-ledger 2000000
+        --from-ledger 1000000 --to-ledger 2000000
 """
+
 from django.core.management.base import BaseCommand, CommandError
 
 from soroscan.ingest.models import TrackedContract
@@ -25,36 +26,61 @@ class Command(BaseCommand):
     help = "Export contract events to Parquet, CSV, JSON, or Avro."
 
     def add_arguments(self, parser):
-        parser.add_argument("--contract-id", required=True, help="Contract ID to export")
+        parser.add_argument("--contract", required=True, help="Contract ID to export")
         parser.add_argument(
             "--format",
             choices=["parquet", "csv", "json", "avro"],
             default="json",
             help="Output format (default: json)",
         )
-        parser.add_argument("--output", required=True, help="Output file path (use - for stdout on csv/json)")
-        parser.add_argument("--start-ledger", type=int, default=None, help="Export events from this ledger (inclusive)")
-        parser.add_argument("--end-ledger", type=int, default=None, help="Export events up to this ledger (inclusive)")
-        parser.add_argument("--batch-size", type=int, default=500, help="Internal streaming batch size (default: 500)")
+        parser.add_argument(
+            "--output", help="Output file path (use - for stdout on csv/json)"
+        )
+        parser.add_argument(
+            "--from-ledger",
+            type=int,
+            default=None,
+            help="Export events from this ledger (inclusive)",
+        )
+        parser.add_argument(
+            "--to-ledger",
+            type=int,
+            default=None,
+            help="Export events up to this ledger (inclusive)",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=500,
+            help="Internal streaming batch size (default: 500)",
+        )
 
     def handle(self, *args, **options):
-        contract_id = options["contract_id"]
+        contract_id = options["contract"]
         fmt = options["format"]
         output = options["output"]
-        start_ledger = options["start_ledger"]
-        end_ledger = options["end_ledger"]
+        from_ledger = options["from_ledger"]
+        to_ledger = options["to_ledger"]
 
         if not TrackedContract.objects.filter(contract_id=contract_id).exists():
-            raise CommandError(f"No TrackedContract found with contract_id={contract_id!r}")
+            raise CommandError(
+                f"No TrackedContract found with contract_id={contract_id!r}"
+            )
 
-        if start_ledger is not None and end_ledger is not None and start_ledger > end_ledger:
-            raise CommandError("--start-ledger must be <= --end-ledger")
+        if (
+            from_ledger is not None
+            and to_ledger is not None
+            and from_ledger > to_ledger
+        ):
+            raise CommandError("--from-ledger must be <= --to-ledger")
 
-        total = _count_events(contract_id, start_ledger, end_ledger)
-        self.stderr.write(f"Exporting {total} events from contract {contract_id} as {fmt} → {output}")
+        total = _count_events(contract_id, from_ledger, to_ledger)
+        self.stderr.write(
+            f"Exporting {total} events from contract {contract_id} as {fmt} → {output}"
+        )
 
         try:
-            count = self._do_export(fmt, contract_id, output, start_ledger, end_ledger)
+            count = self._do_export(fmt, contract_id, output, from_ledger, to_ledger)
         except ImportError as exc:
             raise CommandError(str(exc))
 
@@ -62,25 +88,29 @@ class Command(BaseCommand):
 
     def _do_export(self, fmt, contract_id, output, start_ledger, end_ledger) -> int:
         if fmt == "json":
-            if output == "-":
+            if not output:
                 return export_json(contract_id, self.stdout, start_ledger, end_ledger)
             with open(output, "w", encoding="utf-8") as f:
                 return export_json(contract_id, f, start_ledger, end_ledger)
 
         elif fmt == "csv":
-            if output == "-":
+            if not output:
                 return export_csv(contract_id, self.stdout, start_ledger, end_ledger)
             with open(output, "w", encoding="utf-8", newline="") as f:
                 return export_csv(contract_id, f, start_ledger, end_ledger)
 
         elif fmt == "parquet":
             if output == "-":
-                raise CommandError("Parquet format cannot be written to stdout; provide a file path.")
+                raise CommandError(
+                    "Parquet format cannot be written to stdout; provide a file path."
+                )
             return export_parquet(contract_id, output, start_ledger, end_ledger)
 
         elif fmt == "avro":
             if output == "-":
-                raise CommandError("Avro format cannot be written to stdout; provide a file path.")
+                raise CommandError(
+                    "Avro format cannot be written to stdout; provide a file path."
+                )
             return export_avro(contract_id, output, start_ledger, end_ledger)
 
         raise CommandError(f"Unknown format: {fmt}")


### PR DESCRIPTION
Closes #167 

This PR updates the existing *export_events* management command boilerplate to meet the exact acceptance criteria outlined in the issue.

## Changes Made:
- Argument Mapping: Renamed `--contract-id` to `--contract`, `--start-ledger` to `--from-ledger`, and `--end-ledger` to `--to-ledger`.
- Output Handling: Removed the required constraint from the `--output` argument.

> (Note: Existing Parquet and Avro logic was left untouched as they are scoped for separate issues).

## Validation:
- Confirmed *CSV* and *JSON* exports write correctly to specified files locally.
- Verified the stdout fallback successfully prints headers and data to the terminal.