### PR TITLE
feat: add event-types endpoint with counts

### DIFF
--- a/django-backend/soroscan/ingest/cache_utils.py
+++ b/django-backend/soroscan/ingest/cache_utils.py
@@ -1,10 +1,13 @@
 """
 Redis-backed caching for expensive REST and GraphQL queries (issue #131).
 """
+
 import hashlib
 import json
 from collections.abc import Callable
 from typing import Any
+from functools import wraps
+from rest_framework.response import Response
 
 from django.conf import settings
 from django.core.cache import cache
@@ -38,3 +41,27 @@ def invalidate_contract_query_cache(contract_id: str) -> None:
     """Best-effort: drop stats cache for a contract (pattern-free delete)."""
     # Stats key uses contract_id in payload; callers can delete by known prefixes
     cache.delete(stable_cache_key("contract_stats", {"contract_id": contract_id}))
+
+
+def cache_result(ttl):
+    """Decorator to cache the JSON data of a successful DRF response."""
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            cache_key = f"cache_result:{request.get_full_path()}"
+            cached_data = cache.get(cache_key)
+
+            if cached_data is not None:
+                return Response(cached_data)
+
+            response = view_func(request, *args, **kwargs)
+
+            if response.status_code == 200:
+                cache.set(cache_key, response.data, timeout=ttl)
+
+            return response
+
+        return wrapper
+
+    return decorator

--- a/django-backend/soroscan/ingest/urls.py
+++ b/django-backend/soroscan/ingest/urls.py
@@ -17,6 +17,7 @@ from .views import (
     health_check,
     record_event_view,
     restore_archived_events,
+    get_event_types,
 )
 
 router = DefaultRouter()
@@ -33,6 +34,11 @@ urlpatterns = [
         "contracts/<str:contract_id>/events/explorer/",
         contract_event_explorer_view,
         name="contract-event-explorer",
+    ),
+    path(
+        "contracts/<str:contract_id>/event-types/",
+        get_event_types,
+        name="get_event_types",
     ),
     path("", include(router.urls)),
     path("record/", record_event_view, name="record-event"),

--- a/django-backend/soroscan/ingest/views.py
+++ b/django-backend/soroscan/ingest/views.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 from django.conf import settings
-from django.db.models import Count, Max, Q
+from django.db.models import Count, Max, Min, Q
 from django.db.models.functions import Cast
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
@@ -24,7 +24,7 @@ import requests as http_requests
 
 from soroscan.throttles import IngestRateThrottle
 
-from .cache_utils import get_or_set_json, query_cache_ttl, stable_cache_key
+from .cache_utils import get_or_set_json, query_cache_ttl, stable_cache_key, cache_result
 from .models import (
     APIKey,
     AdminAction,
@@ -838,3 +838,21 @@ def audit_trail_view(request):
 
     serializer = AdminActionSerializer(qs[:limit], many=True)
     return Response(serializer.data)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+@cache_result(ttl=60)
+def get_event_types(request, contract_id: str) -> Response:
+    """GET a summary of event types and counts for a specific contract."""
+
+    result = (
+        ContractEvent.objects.filter(contract__contract_id=contract_id)
+        .values("event_type")
+        .annotate(
+            count=Count("id"), first_seen=Min("timestamp"), last_seen=Max("timestamp")
+        )
+        .order_by("-count")
+    )
+
+    return Response(result)


### PR DESCRIPTION
Closes #182 

This PR introduces a dedicated endpoint to summarize the event types emitted by a specific contract, including their frequencies and timestamp boundaries, without requiring the user to filter through all raw events.

## Changes Made:
- *View Logic:* Added `get_event_types` to `soroscan/ingest/views.py` using Django ORM's `values().annotate()` to group by `event_type` and aggregate counts, `Min('timestamp')`, and `Max('timestamp')`.
- *Caching:* Implemented a reusable `@cache_result(ttl)` decorator in `soroscan/ingest/cache_utils.py` to cache the raw DRF `Response.data` based on the request path, fulfilling the 60s cache requirement.
- *Routing:* Wired the new view to the `contracts/<str:contract_id>/event-types/` path in `soroscan/ingest/urls.py`.

## Testing/Validation:
- Verified the endpoint successfully returns a 200 status code for authenticated requests.
- Confirmed the JSON payload matches the required schema (`event_type`, `count`, `first_seen`, `last_seen`).
- Confirmed results are correctly sorted by `count` in descending order.