### PR TITLE
feat(#173): Add periodic task to clean up old deduplication logs

### DIFF
--- a/django-backend/soroscan/ingest/migrations/0017_eventdeduplicationlog.py
+++ b/django-backend/soroscan/ingest/migrations/0017_eventdeduplicationlog.py
@@ -1,0 +1,104 @@
+# Generated migration for EventDeduplicationLog
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ingest", "0015_merge_notification_and_teams"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EventDeduplicationLog",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "ledger",
+                    models.PositiveBigIntegerField(
+                        db_index=True,
+                        help_text="Ledger sequence number",
+                    ),
+                ),
+                (
+                    "event_index",
+                    models.PositiveIntegerField(
+                        help_text="0-based event index within the ledger",
+                    ),
+                ),
+                (
+                    "tx_hash",
+                    models.CharField(
+                        help_text="Transaction hash",
+                        max_length=64,
+                    ),
+                ),
+                (
+                    "event_type",
+                    models.CharField(
+                        help_text="Event type that was checked",
+                        max_length=100,
+                    ),
+                ),
+                (
+                    "duplicate_detected",
+                    models.BooleanField(
+                        default=False,
+                        help_text="True if a duplicate was detected",
+                    ),
+                ),
+                (
+                    "reason",
+                    models.CharField(
+                        blank=True,
+                        help_text="Reason for the deduplication decision",
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        auto_now_add=True,
+                        db_index=True,
+                        help_text="UTC timestamp of this deduplication check",
+                    ),
+                ),
+                (
+                    "contract",
+                    models.ForeignKey(
+                        help_text="Contract the event belongs to",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="dedup_logs",
+                        to="ingest.trackedcontract",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="eventdeduplicationlog",
+            index=models.Index(
+                fields=["contract", "created_at"],
+                name="ingest_even_contract_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="eventdeduplicationlog",
+            index=models.Index(
+                fields=["contract", "ledger", "event_index"],
+                name="ingest_even_contract_ledger_idx",
+            ),
+        ),
+    ]

--- a/django-backend/soroscan/ingest/models.py
+++ b/django-backend/soroscan/ingest/models.py
@@ -508,6 +508,62 @@ class WebhookDeliveryLog(models.Model):
         return f"Delivery #{self.attempt_number} [{status_label}] sub={self.subscription_id}"
 
 
+class EventDeduplicationLog(models.Model):
+    """
+    Audit log for event deduplication attempts.
+
+    Records are subject to a 90-day TTL: the ``cleanup_old_dedup_logs``
+    Celery task (scheduled via Celery Beat) prunes entries older than 90 days.
+    """
+
+    contract = models.ForeignKey(
+        TrackedContract,
+        on_delete=models.CASCADE,
+        related_name="dedup_logs",
+        help_text="Contract the event belongs to",
+    )
+    ledger = models.PositiveBigIntegerField(
+        db_index=True,
+        help_text="Ledger sequence number",
+    )
+    event_index = models.PositiveIntegerField(
+        help_text="0-based event index within the ledger",
+    )
+    tx_hash = models.CharField(
+        max_length=64,
+        help_text="Transaction hash",
+    )
+    event_type = models.CharField(
+        max_length=100,
+        help_text="Event type that was checked",
+    )
+    duplicate_detected = models.BooleanField(
+        default=False,
+        help_text="True if a duplicate was detected",
+    )
+    reason = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text="Reason for the deduplication decision",
+    )
+    created_at = models.DateTimeField(
+        auto_now_add=True,
+        db_index=True,
+        help_text="UTC timestamp of this deduplication check",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["contract", "created_at"]),
+            models.Index(fields=["contract", "ledger", "event_index"]),
+        ]
+
+    def __str__(self):
+        status = "DUP" if self.duplicate_detected else "NEW"
+        return f"[{status}] {self.event_type}@{self.ledger} ({self.contract.name})"
+
+
 class IndexerState(models.Model):
     """
     Tracks the current indexing state (cursor position).

--- a/django-backend/soroscan/ingest/tasks.py
+++ b/django-backend/soroscan/ingest/tasks.py
@@ -618,6 +618,45 @@ def cleanup_webhook_delivery_logs() -> int:
 
 
 @shared_task
+def cleanup_old_dedup_logs(dry_run: bool = False) -> int:
+    """
+    Prune ``EventDeduplicationLog`` entries older than the configured retention period (TTL cleanup).
+    
+    Args:
+        dry_run: If True, calculate count but don't delete records.
+    
+    Returns:
+        Number of records that were (or would be) deleted.
+    """
+    from django.conf import settings
+    from .models import EventDeduplicationLog
+
+    _start = time.monotonic()
+    retention_days = getattr(settings, "DEDUP_LOG_RETENTION_DAYS", 90)
+    cutoff = timezone.now() - timedelta(days=retention_days)
+    
+    # Get the count of records that would be deleted
+    records_to_delete = EventDeduplicationLog.objects.filter(created_at__lt=cutoff)
+    deleted_count = records_to_delete.count()
+    
+    if not dry_run:
+        # Actually delete the records
+        deleted_count, _ = records_to_delete.delete()
+    
+    logger.info(
+        "Pruned %d EventDeduplicationLog entries older than %d days (dry_run=%s)",
+        deleted_count,
+        retention_days,
+        dry_run,
+        extra={"deletion_count": deleted_count, "retention_days": retention_days, "dry_run": dry_run},
+    )
+    _get_metrics().task_duration_seconds.labels(
+        task_name="cleanup_old_dedup_logs"
+    ).observe(time.monotonic() - _start)
+    return deleted_count
+
+
+@shared_task
 def process_new_event(event_data: dict[str, Any]) -> None:
     """
     Process a newly indexed event and trigger webhooks.

--- a/django-backend/soroscan/ingest/tests/test_tasks.py
+++ b/django-backend/soroscan/ingest/tests/test_tasks.py
@@ -12,8 +12,9 @@ import responses
 from celery.exceptions import Retry
 from django.utils import timezone
 
-from soroscan.ingest.models import AdminAction, RemediationIncident, RemediationRule, WebhookDeliveryLog, WebhookSubscription
+from soroscan.ingest.models import AdminAction, EventDeduplicationLog, RemediationIncident, RemediationRule, WebhookDeliveryLog, WebhookSubscription
 from soroscan.ingest.tasks import (
+    cleanup_old_dedup_logs,
     cleanup_webhook_delivery_logs,
     dispatch_webhook,
     evaluate_remediation_rules,
@@ -502,6 +503,120 @@ class TestCleanupWebhookDeliveryLogs:
     def test_returns_zero_when_nothing_to_prune(self):
         deleted_count = cleanup_webhook_delivery_logs.apply().result
         assert deleted_count == 0
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_dedup_logs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCleanupOldDedupLogs:
+    def test_prunes_old_entries(self, contract):
+        """Verify that logs older than retention period are deleted."""
+        old_log = EventDeduplicationLog.objects.create(
+            contract=contract,
+            ledger=100,
+            event_index=0,
+            tx_hash="abc123",
+            event_type="transfer",
+            duplicate_detected=True,
+            reason="Already exists",
+        )
+        # Manually backdate the created_at via queryset update
+        EventDeduplicationLog.objects.filter(pk=old_log.pk).update(
+            created_at=timezone.now() - timedelta(days=91)
+        )
+        
+        recent_log = EventDeduplicationLog.objects.create(
+            contract=contract,
+            ledger=101,
+            event_index=0,
+            tx_hash="def456",
+            event_type="swap",
+            duplicate_detected=False,
+            reason="New event",
+        )
+
+        deleted_count = cleanup_old_dedup_logs.apply().result
+
+        assert deleted_count == 1
+        assert EventDeduplicationLog.objects.filter(pk=recent_log.pk).exists()
+        assert not EventDeduplicationLog.objects.filter(pk=old_log.pk).exists()
+
+    def test_preserves_recent_entries(self, contract):
+        """Verify that logs within retention period are preserved."""
+        recent_log = EventDeduplicationLog.objects.create(
+            contract=contract,
+            ledger=100,
+            event_index=0,
+            tx_hash="abc123",
+            event_type="transfer",
+            duplicate_detected=True,
+            reason="Already exists",
+        )
+        # Ensure the log is recent (created_at is auto_now_add, so it's already recent)
+        
+        deleted_count = cleanup_old_dedup_logs.apply().result
+
+        assert deleted_count == 0
+        assert EventDeduplicationLog.objects.filter(pk=recent_log.pk).exists()
+
+    def test_dry_run_mode_does_not_delete(self, contract):
+        """Verify that dry_run=True doesn't delete records."""
+        log = EventDeduplicationLog.objects.create(
+            contract=contract,
+            ledger=100,
+            event_index=0,
+            tx_hash="abc123",
+            event_type="transfer",
+            duplicate_detected=True,
+            reason="Already exists",
+        )
+        # Manually backdate the created_at
+        EventDeduplicationLog.objects.filter(pk=log.pk).update(
+            created_at=timezone.now() - timedelta(days=91)
+        )
+        
+        deleted_count = cleanup_old_dedup_logs.apply(kwargs={"dry_run": True}).result
+
+        # Count should be reported
+        assert deleted_count == 1
+        # But record should still exist
+        assert EventDeduplicationLog.objects.filter(pk=log.pk).exists()
+
+    def test_returns_zero_when_nothing_to_prune(self):
+        """Verify task returns 0 when no records match deletion criteria."""
+        deleted_count = cleanup_old_dedup_logs.apply().result
+        assert deleted_count == 0
+
+    def test_respects_retention_days_setting(self, contract):
+        """Verify that the retention_days setting is respected."""
+        from django.test import override_settings
+        
+        # Create a very old log
+        old_log = EventDeduplicationLog.objects.create(
+            contract=contract,
+            ledger=100,
+            event_index=0,
+            tx_hash="abc123",
+            event_type="transfer",
+            duplicate_detected=True,
+            reason="Old",
+        )
+        EventDeduplicationLog.objects.filter(pk=old_log.pk).update(
+            created_at=timezone.now() - timedelta(days=60)
+        )
+        
+        # With default 90 days, this should not be deleted
+        deleted_count = cleanup_old_dedup_logs.apply().result
+        assert deleted_count == 0
+        assert EventDeduplicationLog.objects.filter(pk=old_log.pk).exists()
+        
+        # With 30-day retention, it should be deleted
+        with override_settings(DEDUP_LOG_RETENTION_DAYS=30):
+            deleted_count = cleanup_old_dedup_logs.apply().result
+            assert deleted_count == 1
+            assert not EventDeduplicationLog.objects.filter(pk=old_log.pk).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -237,6 +237,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "soroscan.ingest.tasks.cleanup_webhook_delivery_logs",
         "schedule": 86400,  # daily
     },
+    "cleanup-old-dedup-logs": {
+        "task": "soroscan.ingest.tasks.cleanup_old_dedup_logs",
+        "schedule": 86400,  # daily
+    },
     "cleanup-silk-data": {
         "task": "soroscan.ingest.tasks.cleanup_silk_data",
         "schedule": 604800,  # weekly
@@ -250,6 +254,10 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": 300,  # every 5 minutes
     },
 }
+
+# Data Retention Configuration
+# Number of days to retain deduplication logs before cleanup
+DEDUP_LOG_RETENTION_DAYS = env("DEDUP_LOG_RETENTION_DAYS", default=90, cast=int)
 
 # Stellar / Soroban Configuration
 SOROBAN_RPC_URL = env("SOROBAN_RPC_URL", default="https://soroban-testnet.stellar.org")


### PR DESCRIPTION
- Add EventDeduplicationLog model for tracking event deduplication attempts
- Create cleanup_old_dedup_logs Celery task with dry-run mode support
- Configure task in Celery Beat schedule to run daily
- Add DEDUP_LOG_RETENTION_DAYS setting (default: 90 days, configurable)
- Implement metric tracking for pruned records count
- Create comprehensive tests for cleanup functionality

Tests verify:
- Logs older than retention period are deleted
- Recent logs are preserved
- Dry-run mode doesn't delete records
- Task returns correct deletion count
- Configuration setting is respected

Closes #173