### PR TITLE
fix #282: implement CDC streaming to Kafka/SQS with schema registry support

### DIFF
--- a/django-backend/README.md
+++ b/django-backend/README.md
@@ -65,6 +65,14 @@ celery -A soroscan worker -l info
 celery -A soroscan beat -l info
 ```
 
+## CDC Streaming
+
+SoroScan can publish indexed events to Kafka, Pub/Sub, or SQS for downstream warehouses.
+
+- default Kafka topic: `soroscan.events`
+- schema subject: `soroscan.events-value`
+- integration guide: `docs/cdc-streaming.md`
+
 ## Logging and Sentry
 
 - **Log format**: Set `LOG_FORMAT=json` to emit structured JSON logs (one JSON object per line). Omit or leave unset for human-readable logs. Each JSON line includes `timestamp`, `levelname`, `name` (logger), and `message`; ingest logs also include `request_id`, `contract_id`, and `ledger_sequence` when available.

--- a/django-backend/docs/cdc-streaming.md
+++ b/django-backend/docs/cdc-streaming.md
@@ -1,0 +1,62 @@
+# CDC Streaming Integrations
+
+SoroScan can publish every newly indexed event to downstream systems in real-time.
+
+## Stream payload
+
+- Kafka/PubSub/SQS messages use schema subject `soroscan.events-value`
+- current schema version: `1`
+- default topic name: `soroscan.events`
+
+Event envelope fields:
+
+- `schema_version`
+- `emitted_at`
+- `contract_id`
+- `event_type`
+- `ledger`
+- `event_index`
+- `tx_hash`
+- `payload` (JSON string)
+
+## Enable CDC publishing
+
+Set these environment variables in `django-backend/.env`:
+
+```env
+EVENT_STREAMING_ENABLED=true
+EVENT_STREAMING_BACKEND=kafka
+KAFKA_BOOTSTRAP_SERVERS=broker-1:9092,broker-2:9092
+KAFKA_TOPIC=soroscan.events
+KAFKA_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+```
+
+## Snowflake via Kafka connector
+
+1. Configure SoroScan with Kafka backend (`EVENT_STREAMING_BACKEND=kafka`).
+2. Create Snowflake table and Kafka connector:
+
+```sql
+CREATE TABLE SOROSCAN_EVENTS_RAW (
+  RECORD VARIANT
+);
+```
+
+Use Snowflake Kafka Connector targeting topic `soroscan.events` and load each message body into `RECORD`.
+
+## BigQuery / Redshift patterns
+
+- **BigQuery**: connect Kafka -> BigQuery using Confluent managed sink, mapping to a JSON/STRUCT schema.
+- **Redshift**: connect Kafka -> S3 sink -> Redshift COPY pipeline, or use managed Kafka Connect Redshift sink.
+
+## AWS SQS option
+
+Set:
+
+```env
+EVENT_STREAMING_ENABLED=true
+EVENT_STREAMING_BACKEND=sqs
+SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/soroscan-events
+```
+
+SoroScan publishes one message per event. FIFO queues are supported by automatically setting `MessageGroupId`.

--- a/django-backend/soroscan/ingest/streaming.py
+++ b/django-backend/soroscan/ingest/streaming.py
@@ -1,10 +1,10 @@
-"""
-Event streaming producers for Kafka and Google Pub/Sub.
-"""
+"""CDC event streaming producers for Kafka, Pub/Sub, and AWS queues."""
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
+import requests
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -17,8 +17,57 @@ class BaseProducer:
     def publish(self, contract_id: str, event_data: dict[str, Any]):
         raise NotImplementedError
 
+
+CDC_SCHEMA_SUBJECT = "soroscan.events-value"
+CDC_SCHEMA_VERSION = 1
+CDC_EVENT_SCHEMA_V1 = {
+    "type": "record",
+    "name": "SoroScanEvent",
+    "namespace": "io.soroscan.cdc",
+    "fields": [
+        {"name": "schema_version", "type": "int"},
+        {"name": "emitted_at", "type": "string"},
+        {"name": "contract_id", "type": "string"},
+        {"name": "event_type", "type": ["null", "string"], "default": None},
+        {"name": "ledger", "type": ["null", "long"], "default": None},
+        {"name": "event_index", "type": ["null", "int"], "default": None},
+        {"name": "tx_hash", "type": ["null", "string"], "default": None},
+        {"name": "payload", "type": ["null", "string"], "default": None},
+    ],
+}
+
+
+def build_cdc_envelope(event_data: dict[str, Any]) -> dict[str, Any]:
+    payload = event_data.get("payload")
+    payload_text = json.dumps(payload, separators=(",", ":"), sort_keys=True) if payload else None
+    return {
+        "schema_version": CDC_SCHEMA_VERSION,
+        "emitted_at": datetime.now(timezone.utc).isoformat(),
+        "contract_id": event_data.get("contract_id"),
+        "event_type": event_data.get("event_type"),
+        "ledger": event_data.get("ledger"),
+        "event_index": event_data.get("event_index"),
+        "tx_hash": event_data.get("tx_hash"),
+        "payload": payload_text,
+    }
+
+
+class SchemaRegistryClient:
+    def __init__(self, url: str):
+        self.url = url.rstrip("/")
+
+    def register_schema(self, subject: str, schema_dict: dict[str, Any]) -> None:
+        schema_text = json.dumps(schema_dict, separators=(",", ":"))
+        response = requests.post(
+            f"{self.url}/subjects/{subject}/versions",
+            json={"schemaType": "AVRO", "schema": schema_text},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+
 class KafkaProducer(BaseProducer):
-    def __init__(self, bootstrap_servers: list[str], topic_template: str):
+    def __init__(self, bootstrap_servers: list[str], topic: str, schema_registry_url: str | None = None):
         try:
             from kafka import KafkaProducer as KP
             self.producer = KP(
@@ -28,8 +77,16 @@ class KafkaProducer(BaseProducer):
                 acks=1,
                 retries=3,
             )
-            self.topic_template = topic_template
+            self.topic = topic
             logger.info("Kafka producer initialized with servers: %s", bootstrap_servers)
+            if schema_registry_url:
+                try:
+                    SchemaRegistryClient(schema_registry_url).register_schema(
+                        CDC_SCHEMA_SUBJECT,
+                        CDC_EVENT_SCHEMA_V1,
+                    )
+                except Exception:
+                    logger.exception("Failed to register CDC schema in schema registry")
         except Exception:
             logger.exception("Failed to initialize Kafka producer")
             self.producer = None
@@ -38,16 +95,16 @@ class KafkaProducer(BaseProducer):
         if not self.producer:
             return
 
-        topic = self.topic_template.format(contract_id=contract_id)
         try:
-            # send() is asynchronous and returns a Future
-            self.producer.send(topic, event_data).add_callback(
+            message = build_cdc_envelope(event_data)
+            key = (event_data.get("tx_hash") or contract_id or "").encode("utf-8")
+            self.producer.send(self.topic, message, key=key).add_callback(
                 self._on_success
             ).add_errback(
                 self._on_error
             )
         except Exception:
-            logger.exception("Failed to send event to Kafka topic %s", topic)
+            logger.exception("Failed to send event to Kafka topic %s", self.topic)
             _get_metrics().event_streaming_total.labels(status="failure", backend="kafka").inc()
 
     def _on_success(self, record_metadata):
@@ -58,12 +115,12 @@ class KafkaProducer(BaseProducer):
         _get_metrics().event_streaming_total.labels(status="failure", backend="kafka").inc()
 
 class PubSubProducer(BaseProducer):
-    def __init__(self, project_id: str, topic_template: str):
+    def __init__(self, project_id: str, topic: str):
         try:
             from google.cloud import pubsub_v1
             self.publisher = pubsub_v1.PublisherClient()
             self.project_id = project_id
-            self.topic_template = topic_template
+            self.topic = topic
             logger.info("Pub/Sub producer initialized for project: %s", project_id)
         except Exception:
             logger.exception("Failed to initialize Pub/Sub producer")
@@ -73,11 +130,10 @@ class PubSubProducer(BaseProducer):
         if not self.publisher:
             return
 
-        topic_name = self.topic_template.format(contract_id=contract_id)
-        topic_path = self.publisher.topic_path(self.project_id, topic_name)
+        topic_path = self.publisher.topic_path(self.project_id, self.topic)
         
         try:
-            data = json.dumps(event_data).encode("utf-8")
+            data = json.dumps(build_cdc_envelope(event_data)).encode("utf-8")
             # publish() is asynchronous and returns a Future
             future = self.publisher.publish(topic_path, data)
             future.add_done_callback(self._on_complete)
@@ -92,6 +148,34 @@ class PubSubProducer(BaseProducer):
         except Exception as exc:
             logger.warning("Pub/Sub publish failed: %s", exc)
             _get_metrics().event_streaming_total.labels(status="failure", backend="pubsub").inc()
+
+
+class SQSProducer(BaseProducer):
+    def __init__(self, queue_url: str):
+        self.queue_url = queue_url
+        try:
+            import boto3
+
+            self.client = boto3.client("sqs")
+        except Exception:
+            logger.exception("Failed to initialize SQS producer")
+            self.client = None
+
+    def publish(self, contract_id: str, event_data: dict[str, Any]):
+        if not self.client:
+            return
+        try:
+            params = {
+                "QueueUrl": self.queue_url,
+                "MessageBody": json.dumps(build_cdc_envelope(event_data)),
+            }
+            if self.queue_url.endswith(".fifo"):
+                params["MessageGroupId"] = (event_data.get("tx_hash") or contract_id or "soroscan")[:128]
+            self.client.send_message(**params)
+            _get_metrics().event_streaming_total.labels(status="success", backend="sqs").inc()
+        except Exception:
+            logger.exception("Failed to publish event to SQS queue %s", self.queue_url)
+            _get_metrics().event_streaming_total.labels(status="failure", backend="sqs").inc()
 
 # Singleton-ish access to the configured producer
 _producer_instance = None
@@ -110,14 +194,22 @@ def get_producer():
         kafka_cfg = config.get("kafka", {})
         _producer_instance = KafkaProducer(
             bootstrap_servers=kafka_cfg.get("bootstrap_servers", ["localhost:9092"]),
-            topic_template=kafka_cfg.get("topic_template", "soroscan-events-{contract_id}"),
+            topic=kafka_cfg.get("topic", "soroscan.events"),
+            schema_registry_url=kafka_cfg.get("schema_registry_url"),
         )
     elif backend == "pubsub":
         ps_cfg = config.get("pubsub", {})
         _producer_instance = PubSubProducer(
             project_id=ps_cfg.get("project_id", ""),
-            topic_template=ps_cfg.get("topic_template", "soroscan-events-{contract_id}"),
+            topic=ps_cfg.get("topic", "soroscan.events"),
         )
+    elif backend == "sqs":
+        sqs_cfg = config.get("sqs", {})
+        queue_url = sqs_cfg.get("queue_url", "")
+        if not queue_url:
+            logger.warning("SQS backend enabled but no queue_url configured")
+            return None
+        _producer_instance = SQSProducer(queue_url=queue_url)
     else:
         logger.warning("Unknown streaming backend: %s", backend)
         return None

--- a/django-backend/soroscan/ingest/tasks.py
+++ b/django-backend/soroscan/ingest/tasks.py
@@ -930,6 +930,14 @@ def process_new_event(event_data: dict[str, Any]) -> None:
         event_type__in=[event_type, ""]
     )
 
+    # CDC streaming should not depend on webhook subscriptions.
+    producer = get_producer()
+    if producer:
+        try:
+            producer.publish(contract_id, event_data)
+        except Exception:
+            logger.exception("Failed to stream event to backend", extra={"contract_id": contract_id})
+
     if not webhooks.exists():
         logger.info(
             "No active webhooks for contract %s event_type %s",
@@ -985,14 +993,6 @@ def process_new_event(event_data: dict[str, Any]) -> None:
 
     # Evaluate alert rules asynchronously (separate queue, non-blocking)
     evaluate_alert_rules.apply_async(args=[event_obj.id], queue="default")
-
-    # Stream event to Kafka/PubSub if enabled
-    producer = get_producer()
-    if producer:
-        try:
-            producer.publish(contract_id, event_data)
-        except Exception:
-            logger.exception("Failed to stream event to backend", extra={"contract_id": contract_id})
 
     logger.info(
         "Dispatched event to %s webhooks",

--- a/django-backend/soroscan/ingest/tests/test_streaming.py
+++ b/django-backend/soroscan/ingest/tests/test_streaming.py
@@ -1,11 +1,10 @@
-"""
-Tests for event streaming to Kafka and Pub/Sub.
-"""
+"""Tests for CDC streaming to Kafka/PubSub/SQS."""
 import pytest
 from unittest.mock import patch
 from django.conf import settings
+from soroscan.ingest import streaming
 from soroscan.ingest.tasks import process_new_event
-from .factories import ContractEventFactory, WebhookSubscriptionFactory
+from .factories import ContractEventFactory
 
 @pytest.mark.django_db
 class TestEventStreaming:
@@ -16,16 +15,14 @@ class TestEventStreaming:
         # Setup mock producer
         mock_producer_instance = MockKafkaProducer.return_value
 
-        # Create a webhook subscription so process_new_event doesn't early-return
-        WebhookSubscriptionFactory(contract=contract, event_type="swap")
-
         # Configure settings for Kafka
         streaming_settings = {
             "enabled": True,
             "backend": "kafka",
             "kafka": {
                 "bootstrap_servers": ["localhost:9092"],
-                "topic_template": "soroscan-events-{contract_id}",
+                "topic": "soroscan.events",
+                "schema_registry_url": "",
             },
         }
         
@@ -34,9 +31,7 @@ class TestEventStreaming:
             from soroscan.ingest import streaming
             streaming._producer_instance = None
             
-            event = ContractEventFactory(
-                contract=contract, event_type="swap", ledger=1000, event_index=0
-            )
+            event = ContractEventFactory(contract=contract, event_type="swap", ledger=1000, event_index=0)
             event_data = {
                 "contract_id": contract.contract_id,
                 "event_type": "swap",
@@ -54,6 +49,13 @@ class TestEventStreaming:
                 contract.contract_id, event_data
             )
 
+    @patch("soroscan.ingest.streaming.requests.post")
+    def test_kafka_schema_registry_registration(self, mock_post):
+        mock_post.return_value.raise_for_status.return_value = None
+        client = streaming.SchemaRegistryClient("http://schema-registry:8081")
+        client.register_schema(streaming.CDC_SCHEMA_SUBJECT, streaming.CDC_EVENT_SCHEMA_V1)
+        mock_post.assert_called_once()
+
     @patch("soroscan.ingest.tasks.dispatch_webhook.delay")
     @patch("soroscan.ingest.tasks.evaluate_alert_rules.apply_async")
     @patch("soroscan.ingest.streaming.PubSubProducer")
@@ -61,16 +63,13 @@ class TestEventStreaming:
         # Setup mock producer
         mock_producer_instance = MockPubSubProducer.return_value
 
-        # Create a webhook subscription so process_new_event doesn't early-return
-        WebhookSubscriptionFactory(contract=contract, event_type="swap")
-
         # Configure settings for Pub/Sub
         streaming_settings = {
             "enabled": True,
             "backend": "pubsub",
             "pubsub": {
                 "project_id": "test-project",
-                "topic_template": "soroscan-events-{contract_id}",
+                "topic": "soroscan.events",
             },
         }
         
@@ -119,18 +118,49 @@ class TestEventStreaming:
 
     @patch("soroscan.ingest.tasks.dispatch_webhook.delay")
     @patch("soroscan.ingest.tasks.evaluate_alert_rules.apply_async")
+    @patch("soroscan.ingest.streaming.SQSProducer")
+    def test_process_event_streams_to_sqs_when_enabled(self, MockSQSProducer, MockAlerts, MockWebhooks, contract):
+        mock_producer_instance = MockSQSProducer.return_value
+
+        streaming_settings = {
+            "enabled": True,
+            "backend": "sqs",
+            "sqs": {"queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/soroscan-events"},
+        }
+
+        with patch.object(settings, "EVENT_STREAMING", streaming_settings):
+            from soroscan.ingest import streaming
+
+            streaming._producer_instance = None
+            event = ContractEventFactory(contract=contract, event_type="swap", ledger=2001, event_index=0)
+            event_data = {
+                "contract_id": contract.contract_id,
+                "event_type": event.event_type,
+                "payload": event.payload,
+                "ledger": event.ledger,
+                "event_index": event.event_index,
+                "tx_hash": event.tx_hash,
+            }
+            process_new_event.apply(args=[event_data])
+
+            MockSQSProducer.assert_called_once()
+            mock_producer_instance.publish.assert_called_once_with(contract.contract_id, event_data)
+
+    @patch("soroscan.ingest.tasks.dispatch_webhook.delay")
+    @patch("soroscan.ingest.tasks.evaluate_alert_rules.apply_async")
     @patch("soroscan.ingest.streaming.KafkaProducer")
     def test_streaming_failure_does_not_block_process_new_event(self, MockKafkaProducer, MockAlerts, MockWebhooks, contract):
         mock_producer_instance = MockKafkaProducer.return_value
         mock_producer_instance.publish.side_effect = Exception("Streaming failed")
 
-        # Create a webhook subscription so process_new_event doesn't early-return
-        WebhookSubscriptionFactory(contract=contract, event_type="swap")
-
         streaming_settings = {
             "enabled": True,
             "backend": "kafka",
-            "kafka": {"bootstrap_servers": ["localhost:9092"], "topic_template": "test"},
+            "kafka": {
+                "bootstrap_servers": ["localhost:9092"],
+                "topic": "soroscan.events",
+                "schema_registry_url": "",
+            },
         }
         
         with patch.object(settings, "EVENT_STREAMING", streaming_settings):

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -370,14 +370,18 @@ SLACK_ALERT_TIMEOUT_SECONDS = env.int("SLACK_ALERT_TIMEOUT_SECONDS", default=10)
 # ---------------------------------------------------------------------------
 EVENT_STREAMING = {
     "enabled": env.bool("EVENT_STREAMING_ENABLED", default=False),
-    "backend": env("EVENT_STREAMING_BACKEND", default="kafka"),  # 'kafka' or 'pubsub'
+    "backend": env("EVENT_STREAMING_BACKEND", default="kafka"),  # 'kafka', 'pubsub', or 'sqs'
     "kafka": {
         "bootstrap_servers": env.list("KAFKA_BOOTSTRAP_SERVERS", default=["localhost:9092"]),
-        "topic_template": env("KAFKA_TOPIC_TEMPLATE", default="soroscan-events-{contract_id}"),
+        "topic": env("KAFKA_TOPIC", default="soroscan.events"),
+        "schema_registry_url": env("KAFKA_SCHEMA_REGISTRY_URL", default=""),
     },
     "pubsub": {
         "project_id": env("PUBSUB_PROJECT_ID", default=""),
-        "topic_template": env("PUBSUB_TOPIC_TEMPLATE", default="soroscan-events-{contract_id}"),
+        "topic": env("PUBSUB_TOPIC", default="soroscan.events"),
+    },
+    "sqs": {
+        "queue_url": env("SQS_QUEUE_URL", default=""),
     },
 }
 

--- a/django-backend/soroscan/settings_test.py
+++ b/django-backend/soroscan/settings_test.py
@@ -153,11 +153,15 @@ EVENT_STREAMING = {
     "backend": "kafka",
     "kafka": {
         "bootstrap_servers": ["localhost:9092"],
-        "topic_template": "soroscan-events-{contract_id}",
+        "topic": "soroscan.events",
+        "schema_registry_url": "",
     },
     "pubsub": {
         "project_id": "test-project",
-        "topic_template": "soroscan-events-{contract_id}",
+        "topic": "soroscan.events",
+    },
+    "sqs": {
+        "queue_url": "",
     },
 }
 


### PR DESCRIPTION
## Summary
- switch event streaming to a schema-versioned CDC envelope with default Kafka topic `soroscan.events`
- add schema registry registration support for Kafka and add an AWS SQS backend for enterprise queue consumers
- make CDC publishing independent of webhook subscriptions and document Snowflake/BigQuery/Redshift integration paths

Closes #282.

## Test plan
- `DJANGO_SETTINGS_MODULE=soroscan.settings_test .venv-local/bin/pytest soroscan/ingest/tests/test_streaming.py soroscan/ingest/tests/test_views.py soroscan/ingest/tests/test_schema.py -q`
- `DJANGO_SETTINGS_MODULE=soroscan.settings_test .venv-local/bin/pytest -q`

Made with [Cursor](https://cursor.com)