### PR TITLE
feat: add reusable Alert component with 4 variants and tests

### DIFF
--- a/soroscan-frontend/__tests__/ui-alert.test.tsx
+++ b/soroscan-frontend/__tests__/ui-alert.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { Alert } from "@/components/ui/alert"
+
+describe("Alert Component", () => {
+  it("renders all 4 variants correctly", () => {
+    const variants = ["info", "success", "warning", "error"] as const
+    variants.forEach((v) => {
+      const { unmount } = render(<Alert variant={v} title={`${v} alert`} />)
+      expect(screen.getByText(`${v} alert`)).toBeInTheDocument()
+      unmount()
+    })
+  })
+
+  it("handles the dismissible toggle", () => {
+    const onDismiss = jest.fn()
+    render(<Alert title="Dismissible" onDismiss={onDismiss} />)
+    const button = screen.getByLabelText("Dismiss alert")
+    fireEvent.click(button)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("displays title and description in the correct layout", () => {
+    render(<Alert title="Alert Title" description="Detailed info here" />)
+    expect(screen.getByText("Alert Title")).toBeInTheDocument()
+    expect(screen.getByText("Detailed info here")).toBeInTheDocument()
+  })
+})

--- a/soroscan-frontend/components/ui/alert.tsx
+++ b/soroscan-frontend/components/ui/alert.tsx
@@ -1,0 +1,67 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { AlertCircle, CheckCircle2, Info, XCircle, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid grid-cols-[auto_1fr_auto] gap-3 items-start [&>svg]:size-5",
+  {
+    variants: {
+      variant: {
+        info: "bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800",
+        success: "bg-green-50 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800",
+        warning: "bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800",
+        error: "bg-red-50 text-red-800 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+    },
+  }
+)
+
+const variantIcons = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertCircle,
+  error: XCircle,
+}
+
+interface AlertProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof alertVariants> {
+  title?: string
+  description?: string
+  onDismiss?: () => void
+}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant = "info", title, description, onDismiss, ...props }, ref) => {
+    const Icon = variantIcons[variant || "info"]
+
+    return (
+      <div
+        ref={ref}
+        role="alert"
+        className={cn(alertVariants({ variant }), className)}
+        {...props}
+      >
+        <Icon className="mt-0.5" aria-hidden="true" />
+        <div className="flex flex-col gap-1">
+          {title && <h5 className="font-semibold leading-none tracking-tight">{title}</h5>}
+          {description && <div className="text-sm opacity-90">{description}</div>}
+        </div>
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="p-1 rounded-md hover:bg-black/5 dark:hover:bg-white/10 transition-colors cursor-pointer"
+            aria-label="Dismiss alert"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+    )
+  }
+)
+Alert.displayName = "Alert"
+
+export { Alert, alertVariants }


### PR DESCRIPTION
Title
feat: add reusable Alert component with variants and tests

Description
This PR introduces a reusable Alert component to the UI library. It is designed to provide feedback to users via four distinct variants: Info, Success, Warning, and Error.
Closes #262

Changes

New Component: Created components/ui/alert.tsx using class-variance-authority (CVA) for styling and lucide-react for iconography.


Variants: Implemented color-coded backgrounds and matching icons for all four required states.


Features: Added a title, description, and an optional onDismiss toggle for dismissible alerts.


Accessibility: Added role="alert" and aria-label for screen readers.


Testing: Created __tests__/ui-alert.test.tsx which verifies variant rendering, layout, and dismiss logic.

Acceptance Criteria Progress
[x] Alert component supports 4 variants: info, success, warning, and error.

[x] Dismissible toggle works: Functional onDismiss callback and close button.

[x] Icons display correctly: Integrated lucide-react icons mapped to each variant.

[x] Colors match design system: Aligned with the project's Tailwind 4 configuration.

[x] Tests verify all variants: All tests passed in the local environment.

Verification Results
Tests passed successfully:

Plaintext
PASS  __tests__/ui-alert.test.tsx
  Alert Component
    √ renders all 4 variants correctly
    √ handles the dismissible toggle
    √ displays title and description in the correct layout
Note
Running npm run lint revealed pre-existing warnings in app/admin/page.tsx and i18n.ts. These are unrelated to this PR and were left untouched to maintain the specific scope of this task.
<img width="1365" height="719" alt="Screenshot 2026-04-23 122710" src="https://github.com/user-attachments/assets/8a90e438-74ac-45e4-84e2-6088e11850dd" />
