### PR TITLE
feat(ui): build text input component with validation states #267

### DIFF
--- a/soroscan-frontend/__tests__/input.test.tsx
+++ b/soroscan-frontend/__tests__/input.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react"
+import { Input } from "../components/ui/input"
+import { Label } from "../components/ui/label"
+import "@testing-library/jest-dom"
+
+describe("Input Component with Validation States", () => {
+  it("should render the label and accept text", () => {
+    render(
+      <div>
+        <Label htmlFor="test-input">Username</Label>
+        <Input id="test-input" placeholder="Enter username" />
+      </div>
+    )
+    const input = screen.getByPlaceholderText("Enter username")
+    expect(screen.getByText("Username")).toBeInTheDocument()
+    expect(input).toBeInTheDocument()
+  })
+
+  it("should show required indicator when required prop is passed", () => {
+    render(<Label required>Email</Label>)
+    expect(screen.getByText("*")).toBeInTheDocument()
+    expect(screen.getByText("*")).toHaveClass("text-destructive")
+  })
+
+  it("should apply error styles when state is error", () => {
+    render(<Input state="error" data-testid="error-input" />)
+    const input = screen.getByTestId("error-input")
+    expect(input).toHaveClass("border-destructive")
+    expect(input).toHaveAttribute("aria-invalid", "true")
+  })
+
+  it("should apply success styles when state is success", () => {
+    render(<Input state="success" data-testid="success-input" />)
+    const input = screen.getByTestId("success-input")
+    expect(input).toHaveClass("border-green-500")
+  })
+
+  it("should be disabled when disabled prop is passed", () => {
+    render(<Input disabled placeholder="Disabled input" />)
+    const input = screen.getByPlaceholderText("Disabled input")
+    expect(input).toBeDisabled()
+  })
+})

--- a/soroscan-frontend/components/ui/input.tsx
+++ b/soroscan-frontend/components/ui/input.tsx
@@ -1,18 +1,26 @@
 import * as React from "react"
-
 import { cn } from "@/lib/utils"
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  function Input({ className, type, ...props }, ref) {
+export interface InputProps extends React.ComponentProps<"input"> {
+  state?: "default" | "error" | "success"
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  function Input({ className, type, state = "default", ...props }, ref) {
     return (
       <input
         ref={ref}
         type={type}
         data-slot="input"
+        data-state={state}
+        aria-invalid={state === "error"}
         className={cn(
           "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          // Error State
+          state === "error" && "border-destructive focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+          // Success State
+          state === "success" && "border-green-500 focus-visible:ring-green-500/20 dark:focus-visible:ring-green-500/40",
           className
         )}
         {...props}

--- a/soroscan-frontend/components/ui/label.tsx
+++ b/soroscan-frontend/components/ui/label.tsx
@@ -2,22 +2,26 @@
 
 import * as React from "react"
 import { Label as LabelPrimitive } from "radix-ui"
-
 import { cn } from "@/lib/utils"
 
 function Label({
   className,
+  required,
+  children,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.ComponentProps<typeof LabelPrimitive.Root> & { required?: boolean }) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-1 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}
-    />
+    >
+      {children}
+      {required && <span className="text-destructive" aria-hidden="true">*</span>}
+    </LabelPrimitive.Root>
   )
 }
 


### PR DESCRIPTION
## Description
This PR enhances the base Input and Label components to support validation states (Error, Success), disabled states, and required indicators as per the requirements in #267.

## Changes
- Updated `components/ui/input.tsx` to include a `state` prop for "error" and "success" visual variants.
- Updated `components/ui/label.tsx` to include a `required` prop that automatically appends a styled asterisk (*).
- Integrated `aria-invalid` attributes for better accessibility when in an error state.
- Added comprehensive unit tests in `__tests__/input.test.tsx` to verify all visual states and prop behaviors.

## Acceptance Criteria Check
- [x] Input accepts text
- [x] Label displays correctly
- [x] Error state colors (red border) apply correctly
- [x] Success state colors (green border) apply correctly
- [x] Required indicator (*) shows when prop is passed
- [x] Disabled state prevents user input
- [x] Tests verify all states
Closes #267