### PR TITLE
Add webhook event type validation and ingest dry-run command

### DIFF
--- a/django-backend/soroscan/ingest/admin.py
+++ b/django-backend/soroscan/ingest/admin.py
@@ -474,6 +474,44 @@ class WebhookSubscriptionAdmin(AdminAuditMixin, admin.ModelAdmin):
     )
     ordering = ["-created_at"]
 
+    class Media:
+        js = ("ingest/admin_event_type_autocomplete.js",)
+
+    def get_urls(self):
+        from django.urls import path
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "event-types/",
+                self.admin_site.admin_view(self.event_types_api),
+                name="webhooksubscription_event_types",
+            ),
+        ]
+        return custom_urls + urls
+
+    def event_types_api(self, request):
+        from django.http import JsonResponse
+        from soroscan.ingest.models import TrackedContract
+        contract_id = request.GET.get("contract_id")
+        if not contract_id:
+            return JsonResponse({"results": []})
+        try:
+            contract = TrackedContract.objects.get(pk=contract_id)
+        except TrackedContract.DoesNotExist:
+            return JsonResponse({"results": []})
+        
+        types = set()
+        if hasattr(contract, "event_schemas"):
+            types.update(contract.event_schemas.values_list("event_type", flat=True))
+        if hasattr(contract, "abi") and contract.abi.abi_json:
+            for ev in contract.abi.abi_json:
+                if isinstance(ev, dict) and ev.get("name"):
+                    types.add(ev["name"])
+        types.update(contract.events.values_list("event_type", flat=True).distinct())
+        
+        results = [{"id": t, "text": t} for t in sorted(types)]
+        return JsonResponse({"results": results})
+
     def get_queryset(self, request):
         """Optimize queries with select_related to prevent N+1 issues."""
         queryset = super().get_queryset(request)

--- a/django-backend/soroscan/ingest/management/commands/ingest_events.py
+++ b/django-backend/soroscan/ingest/management/commands/ingest_events.py
@@ -1,0 +1,77 @@
+import json
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+from stellar_sdk import SorobanServer
+from soroscan.ingest.models import TrackedContract
+from soroscan.ingest.tasks import validate_contract_payload_schema, validate_event_payload, _upsert_contract_event
+from soroscan.ingest.stellar_client import SorobanClient
+
+class Command(BaseCommand):
+    help = "Ingest events for a given contract with optional dry run."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--contract", required=True, help="Target tracked contract ID")
+        parser.add_argument("--dry-run", action="store_true", help="Fetches and validates but does not persist")
+
+    def handle(self, *args, **options):
+        contract_id = options["contract"]
+        dry_run = options["dry_run"]
+
+        try:
+            contract = TrackedContract.objects.get(contract_id=contract_id)
+        except TrackedContract.DoesNotExist:
+            raise CommandError(f"TrackedContract with ID {contract_id} does not exist.")
+
+        server = SorobanServer(settings.SOROBAN_RPC_URL)
+        filters = [{"type": "contract", "contractIds": [contract.contract_id]}]
+        
+        # fetch latest events
+        kwargs = {"filters": filters, "pagination": {"limit": 100}}
+        if contract.last_indexed_ledger and contract.last_indexed_ledger > 0:
+            kwargs["start_ledger"] = contract.last_indexed_ledger
+
+        self.stdout.write(f"Fetching events for {contract_id}...")
+        try:
+            events_response = server.get_events(**kwargs)
+        except Exception as e:
+            raise CommandError(f"Failed to fetch events: {e}")
+        
+        events = getattr(events_response, "events", [])
+        
+        self.stdout.write(self.style.SUCCESS(f"Fetched {len(events)} events."))
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("[DRY RUN] Summary of fetched events:"))
+            self.stdout.write(f"Total events found: {len(events)}")
+            if events:
+                self.stdout.write("Sample events:")
+                for idx, event in enumerate(events[:5]):
+                    payload = getattr(event, "value", None) or getattr(event, "payload", {})
+                    event_type = getattr(event, "type", "unknown")
+                    ledger = getattr(event, "ledger", None)
+                    
+                    p1 = validate_contract_payload_schema(contract, payload, event_type, ledger=ledger)
+                    p2, _ = validate_event_payload(contract, event_type, payload, ledger=ledger)
+                    valid = p1 and p2
+                    
+                    status_str = "VALID" if valid else "INVALID"
+                    self.stdout.write(f" - Event #{idx+1}: type='{event_type}', ledger={ledger}, status={status_str}")
+                if len(events) > 5:
+                    self.stdout.write(" ...")
+            self.stdout.write(self.style.WARNING("Dry run complete. No data persisted."))
+            return
+
+        client = SorobanClient()
+        batch_cache = {}
+        processed = 0
+        for fallback_idx, event in enumerate(events):
+            _upsert_contract_event(
+                contract, 
+                event, 
+                fallback_event_index=fallback_idx, 
+                client=client, 
+                batch_cache=batch_cache
+            )
+            processed += 1
+            
+        self.stdout.write(self.style.SUCCESS(f"Successfully processed {processed} events."))

--- a/django-backend/soroscan/ingest/management/commands/ingest_events.py
+++ b/django-backend/soroscan/ingest/management/commands/ingest_events.py
@@ -1,4 +1,3 @@
-import json
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from stellar_sdk import SorobanServer

--- a/django-backend/soroscan/ingest/models.py
+++ b/django-backend/soroscan/ingest/models.py
@@ -604,7 +604,6 @@ class WebhookSubscription(models.Model):
         # Auto-generate secret if not set
         if not self.secret:
             self.secret = secrets.token_hex(32)
-        self.clean()
         super().save(*args, **kwargs)
 
 

--- a/django-backend/soroscan/ingest/models.py
+++ b/django-backend/soroscan/ingest/models.py
@@ -581,10 +581,30 @@ class WebhookSubscription(models.Model):
     def __str__(self):
         return f"Webhook -> {self.target_url} ({self.contract.name})"
 
+    def get_known_event_types(self):
+        types = set()
+        if hasattr(self.contract, "event_schemas"):
+            types.update(self.contract.event_schemas.values_list("event_type", flat=True))
+        if hasattr(self.contract, "abi") and self.contract.abi.abi_json:
+            for ev in self.contract.abi.abi_json:
+                if isinstance(ev, dict) and ev.get("name"):
+                    types.add(ev["name"])
+        types.update(self.contract.events.values_list("event_type", flat=True).distinct())
+        return types
+
+    def clean(self):
+        super().clean()
+        if self.event_type and self.contract_id:
+            known = self.get_known_event_types()
+            if known and self.event_type not in known:
+                from django.core.exceptions import ValidationError
+                raise ValidationError({"event_type": f"Invalid event type. Available types: {', '.join(sorted(known))}"})
+
     def save(self, *args, **kwargs):
         # Auto-generate secret if not set
         if not self.secret:
             self.secret = secrets.token_hex(32)
+        self.clean()
         super().save(*args, **kwargs)
 
 

--- a/django-backend/soroscan/ingest/static/ingest/admin_event_type_autocomplete.js
+++ b/django-backend/soroscan/ingest/static/ingest/admin_event_type_autocomplete.js
@@ -1,0 +1,31 @@
+django.jQuery(function($) {
+    const contractSelect = $('#id_contract');
+    const eventTypeInput = $('#id_event_type');
+    
+    // Convert to a datalist
+    const datalistId = 'event_type_list';
+    eventTypeInput.attr('list', datalistId);
+    if ($('#' + datalistId).length === 0) {
+        eventTypeInput.after('<datalist id="' + datalistId + '"></datalist>');
+    }
+    
+    function updateEventTypes() {
+        const contractId = contractSelect.val();
+        const datalist = $('#' + datalistId);
+        datalist.empty();
+        
+        if (contractId) {
+            $.getJSON('/admin/ingest/webhooksubscription/event-types/?contract_id=' + contractId, function(data) {
+                if (data.results) {
+                    data.results.forEach(function(item) {
+                        datalist.append($('<option>', {value: item.id}));
+                    });
+                }
+            });
+        }
+    }
+    
+    contractSelect.on('change', updateEventTypes);
+    // run on load
+    updateEventTypes();
+});


### PR DESCRIPTION
closes #217
closes #218

### Summary
This PR implements validation mechanisms against webhook event subscriptions and provisions a dry-run tool for the ingest pipeline to safely verify schema processing.

### Key Changes
- **Task 1 (Webhook Schema Validation):** Added [get_known_event_types()](cci:1://file:///home/nusrat/Desktop/yusrah/soroscan/django-backend/soroscan/ingest/models.py:583:4-592:20) method to `WebhookSubscription.clean()`. It raises `ValidationError` on incorrectly formed names. Implemented an autocomplete `<datalist>` behavior in the Django admin UI using an internal API endpoint that fetches valid available schemas based on [contract_id](cci:1://file:///home/nusrat/Desktop/yusrah/soroscan/django-backend/soroscan/ingest/admin.py:326:4-329:82).
- **Task 2 (Ingest Pipeline Check):** Created a management command `python manage.py ingest_events --contract=<address> --dry-run`. It runs validation and schema decoding routines using `stellar_sdk` over the most recent contract ledger events but does not persist anything when running a `--dry-run`, thus giving operators a safe way to verify configurations before full ingestion.
