### PR TITLE
feat: add tab navigation component with keyboard support

### DIFF
--- a/soroscan-frontend/__tests__/ui-tabs.test.tsx
+++ b/soroscan-frontend/__tests__/ui-tabs.test.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { Tabs } from "@/components/ui/tabs"
+
+describe("Tabs", () => {
+  const items = [
+    { id: "overview", title: "Overview", content: <p>Overview content</p> },
+    { id: "details", title: "Details", content: <p>Details content</p> },
+    { id: "history", title: "History", content: <p>History content</p> },
+  ]
+
+  it("renders a horizontal tablist with accessible roles", () => {
+    render(<Tabs items={items} />)
+
+    const tablist = screen.getByRole("tablist")
+    expect(tablist).toBeInTheDocument()
+
+    const tabs = screen.getAllByRole("tab")
+    expect(tabs).toHaveLength(3)
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true")
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false")
+  })
+
+  it("switches content when a tab is clicked", () => {
+    render(<Tabs items={items} />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Details" }))
+
+    expect(screen.getByText("Details content")).toBeInTheDocument()
+    expect(screen.queryByText("Overview content")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+  })
+
+  it("navigates tabs with arrow keys", () => {
+    render(<Tabs items={items} />)
+
+    const firstTab = screen.getByRole("tab", { name: "Overview" })
+    firstTab.focus()
+    fireEvent.keyDown(firstTab, { key: "ArrowRight", code: "ArrowRight" })
+
+    const secondTab = screen.getByRole("tab", { name: "Details" })
+    expect(secondTab).toHaveFocus()
+    expect(secondTab).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByText("Details content")).toBeInTheDocument()
+  })
+
+  it("applies a visible active indicator to the selected tab", async () => {
+    render(<Tabs items={items} />)
+
+    const selectedTab = screen.getByRole("tab", { name: "Overview" })
+    expect(selectedTab).toHaveClass("border-b-2")
+  })
+})

--- a/soroscan-frontend/components/ui/tabs.tsx
+++ b/soroscan-frontend/components/ui/tabs.tsx
@@ -1,0 +1,111 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TabItem {
+  id: string
+  title: string
+  content: React.ReactNode
+}
+
+export interface TabsProps {
+  items: TabItem[]
+  defaultIndex?: number
+  className?: string
+}
+
+export function Tabs({ items, defaultIndex = 0, className }: TabsProps) {
+  const [activeIndex, setActiveIndex] = React.useState(
+    Math.min(Math.max(defaultIndex, 0), items.length - 1)
+  )
+  const id = React.useId()
+  const tabRefs = React.useRef<Array<HTMLButtonElement | null>>([])
+
+  const focusTab = (index: number) => {
+    const nextIndex = (index + items.length) % items.length
+    setActiveIndex(nextIndex)
+    tabRefs.current[nextIndex]?.focus()
+  }
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    switch (event.key) {
+      case "ArrowRight":
+        event.preventDefault()
+        focusTab(index + 1)
+        break
+      case "ArrowLeft":
+        event.preventDefault()
+        focusTab(index - 1)
+        break
+      case "Home":
+        event.preventDefault()
+        focusTab(0)
+        break
+      case "End":
+        event.preventDefault()
+        focusTab(items.length - 1)
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    <div className={cn("w-full", className)}>
+      <div
+        role="tablist"
+        aria-label="Tab navigation"
+        className="flex flex-wrap gap-2 border-b border-slate-200 dark:border-slate-700"
+      >
+        {items.map((item, index) => {
+          const selected = index === activeIndex
+          return (
+            <button
+              key={item.id}
+              ref={(element) => {
+                tabRefs.current[index] = element
+              }}
+              id={`${id}-tab-${item.id}`}
+              role="tab"
+              type="button"
+              aria-selected={selected}
+              aria-controls={`${id}-panel-${item.id}`}
+              tabIndex={selected ? 0 : -1}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              onClick={() => setActiveIndex(index)}
+              className={cn(
+                "rounded-t-md px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/80",
+                selected
+                  ? "border-b-2 border-primary text-primary"
+                  : "text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100"
+              )}
+            >
+              {item.title}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="mt-4">
+        {items.map((item, index) => {
+          const selected = index === activeIndex
+          return (
+            <div
+              key={item.id}
+              id={`${id}-panel-${item.id}`}
+              role="tabpanel"
+              aria-labelledby={`${id}-tab-${item.id}`}
+              hidden={!selected}
+              className="focus-visible:outline-none"
+            >
+              {selected && item.content}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #264

---

 Completed

- Branch: `feature/tab-navigation-keyboard-support`
- Added:
  - tabs.tsx
  - ui-tabs.test.tsx

 What the component includes

- Horizontal tab navigation
- Click-to-switch behavior
- Arrow key navigation (`ArrowRight`, `ArrowLeft`, `Home`, `End`)
- Active tab visual indicator
- Accessible ARIA roles: `tablist`, `tab`, `tabpanel`

 Validation status

- Verified the files were created successfully
- Test execution was blocked by the local frontend environment: Jest configuration depends on `next/jest`, which is unavailable in the current install/setup

