### PR TITLE
Feat: Log all GraphQL resolver calls with query name and duration

### DIFF
--- a/django-backend/soroscan/graphql_extensions.py
+++ b/django-backend/soroscan/graphql_extensions.py
@@ -1,0 +1,95 @@
+import inspect
+import logging
+import time
+import traceback
+from typing import Any, Callable, Dict, Optional
+
+from strawberry.extensions import SchemaExtension
+from strawberry.types import Info
+
+logger = logging.getLogger("soroscan.graphql")
+
+
+class GraphQLResolverLoggingExtension(SchemaExtension):
+    """
+    Strawberry extension to log all GraphQL resolver calls.
+
+    Logs query start, completion/duration, arguments, and full stack traces for errors.
+    Only logs top-level Query and Mutation fields to avoid clutter.
+    """
+
+    def resolve(
+        self,
+        _next: Callable,
+        root: Any,
+        info: Info,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        # Only log top-level Query and Mutation resolvers
+        if info.parent_type.name not in ("Query", "Mutation"):
+            return _next(root, info, *args, **kwargs)
+
+        query_name = info.field_name
+        start_time = time.perf_counter()
+
+        # Log arguments (kwargs contains the GraphQL arguments)
+        logger.info(
+            f"GraphQL resolver started: {query_name}",
+            extra={
+                "query_name": query_name,
+                "arguments": kwargs,
+            },
+        )
+
+        try:
+            result = _next(root, info, *args, **kwargs)
+
+            # Handle async resolvers
+            if inspect.isawaitable(result):
+
+                async def wrap_awaitable(awaitable):
+                    try:
+                        res = await awaitable
+                        self._log_completion(query_name, start_time, kwargs, "Success")
+                        return res
+                    except Exception as e:
+                        self._log_completion(query_name, start_time, kwargs, "Error", e)
+                        raise e
+
+                return wrap_awaitable(result)
+
+            self._log_completion(query_name, start_time, kwargs, "Success")
+            return result
+        except Exception as e:
+            self._log_completion(query_name, start_time, kwargs, "Error", e)
+            raise e
+
+    def _log_completion(
+        self,
+        query_name: str,
+        start_time: float,
+        arguments: Dict[str, Any],
+        status: str,
+        error: Optional[Exception] = None,
+    ) -> None:
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        extra = {
+            "query_name": query_name,
+            "arguments": arguments,
+            "duration_ms": round(duration_ms, 2),
+            "status": status,
+        }
+
+        if error:
+            extra["error"] = str(error)
+            extra["stack_trace"] = traceback.format_exc()
+            logger.error(
+                f"GraphQL resolver failed: {query_name} in {duration_ms:.2f}ms",
+                extra=extra,
+            )
+        else:
+            logger.info(
+                f"GraphQL resolver completed: {query_name} in {duration_ms:.2f}ms",
+                extra=extra,
+            )

--- a/django-backend/soroscan/ingest/schema.py
+++ b/django-backend/soroscan/ingest/schema.py
@@ -28,7 +28,7 @@ from .models import (
     WebhookDeliveryLog,
 )
 from .services.timeline import build_timeline
-from soroscan.graphql_extensions import GraphQLResolverLoggingExtension
+from ..graphql_extensions import GraphQLResolverLoggingExtension
 
 
 def _get_authenticated_user(info: Info):

--- a/django-backend/soroscan/ingest/schema.py
+++ b/django-backend/soroscan/ingest/schema.py
@@ -28,6 +28,7 @@ from .models import (
     WebhookDeliveryLog,
 )
 from .services.timeline import build_timeline
+from soroscan.graphql_extensions import GraphQLResolverLoggingExtension
 
 
 def _get_authenticated_user(info: Info):
@@ -1135,4 +1136,9 @@ class Subscription:
             await channel_layer.group_discard(group_name, channel_name)
 
 
-schema = strawberry.Schema(query=Query, mutation=Mutation, subscription=Subscription)
+schema = strawberry.Schema(
+    query=Query,
+    mutation=Mutation,
+    subscription=Subscription,
+    extensions=[GraphQLResolverLoggingExtension],
+)

--- a/django-backend/soroscan/ingest/tests/test_graphql_logging.py
+++ b/django-backend/soroscan/ingest/tests/test_graphql_logging.py
@@ -1,0 +1,118 @@
+import pytest
+from unittest.mock import patch, MagicMock, call
+from soroscan.ingest.schema import schema
+from .factories import TrackedContractFactory
+
+@pytest.mark.django_db
+class TestGraphQLLogging:
+    @patch("soroscan.graphql_extensions.logger")
+    def test_resolver_logging_success(self, mock_logger):
+        # Create a contract to query
+        contract = TrackedContractFactory(name="Test Contract")
+        
+        query = f"""
+            query {{
+                contract(contractId: "{contract.contract_id}") {{
+                    name
+                }}
+            }}
+        """
+        
+        # Execute query
+        result = schema.execute_sync(query)
+        assert result.errors is None
+        
+        # Verify "started" log
+        # GraphQL arguments are passed to extensions as they appear in the query (un-snake-cased)
+        mock_logger.info.assert_any_call(
+            "GraphQL resolver started: contract",
+            extra={
+                "query_name": "contract",
+                "arguments": {"contractId": contract.contract_id}
+            }
+        )
+        
+        # Verify "completed" log
+        completed_calls = [
+            c for c in mock_logger.info.call_args_list 
+            if "GraphQL resolver completed" in c[0][0]
+        ]
+        assert len(completed_calls) == 1
+        
+        extra = completed_calls[0].kwargs["extra"]
+        assert extra["query_name"] == "contract"
+        assert extra["status"] == "Success"
+        assert "duration_ms" in extra
+        assert extra["arguments"] == {"contractId": contract.contract_id}
+
+    @patch("soroscan.graphql_extensions.logger")
+    @patch("soroscan.ingest.schema.TrackedContract.objects")
+    def test_resolver_logging_error(self, mock_objects, mock_logger):
+        # Mock an error in the resolver (top-level query)
+        mock_objects.select_related.return_value.get.side_effect = Exception("Test Database Error")
+        
+        query = """
+            query {
+                contract(contractId: "any-id") {
+                    name
+                }
+            }
+        """
+        
+        # Execute query
+        result = schema.execute_sync(query)
+        assert result.errors is not None
+        
+        # Verify "started" log
+        mock_logger.info.assert_any_call(
+            "GraphQL resolver started: contract",
+            extra={
+                "query_name": "contract",
+                "arguments": {"contractId": "any-id"}
+            }
+        )
+        
+        # Verify "failed" log
+        mock_logger.error.assert_called_once()
+        log_args, log_kwargs = mock_logger.error.call_args
+        assert "GraphQL resolver failed: contract" in log_args[0]
+        
+        extra = log_kwargs["extra"]
+        assert extra["query_name"] == "contract"
+        assert extra["status"] == "Error"
+        assert extra["error"] == "Test Database Error"
+        assert "stack_trace" in extra
+        assert "duration_ms" in extra
+
+    @patch("soroscan.graphql_extensions.logger")
+    def test_no_logging_for_non_top_level_fields(self, mock_logger):
+        # Create a contract with metadata
+        contract = TrackedContractFactory(name="Test Contract")
+        
+        query = f"""
+            query {{
+                contract(contractId: "{contract.contract_id}") {{
+                    name
+                    verificationStatus
+                }}
+            }}
+        """
+        
+        # Execute query
+        schema.execute_sync(query)
+        
+        # Verify only the top-level 'contract' resolver was logged
+        # started and completed logs for 'contract'
+        started_calls = [c for c in mock_logger.info.call_args_list if "started" in c[0][0]]
+        completed_calls = [c for c in mock_logger.info.call_args_list if "completed" in c[0][0]]
+        
+        assert len(started_calls) == 1
+        assert started_calls[0].kwargs["extra"]["query_name"] == "contract"
+        
+        assert len(completed_calls) == 1
+        assert completed_calls[0].kwargs["extra"]["query_name"] == "contract"
+        
+        # 'name' and 'verificationStatus' should NOT be logged as they are fields of ContractType, not top-level Query
+        query_names = [c.kwargs["extra"].get("query_name") for c in mock_logger.info.call_args_list]
+        assert "name" not in query_names
+        assert "verificationStatus" not in query_names

--- a/django-backend/soroscan/ingest/tests/test_graphql_logging.py
+++ b/django-backend/soroscan/ingest/tests/test_graphql_logging.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch
 from soroscan.ingest.schema import schema
 from .factories import TrackedContractFactory
 


### PR DESCRIPTION
closes #276 