### PR TITLE
feat: build accessible alert component with variants and dismiss toggle

### DIFF
--- a/soroscan-frontend/__tests__/ui-alert.test.tsx
+++ b/soroscan-frontend/__tests__/ui-alert.test.tsx
@@ -1,27 +1,36 @@
+import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
-import { Alert } from "@/components/ui/alert"
+import { Alert } from "../components/ui/alert"
 
 describe("Alert Component", () => {
-  it("renders all 4 variants correctly", () => {
+  it("renders the title and description correctly", () => {
+    render(<Alert title="System Update" description="Your profile has been updated." />)
+    expect(screen.getByText("System Update")).toBeInTheDocument()
+    expect(screen.getByText("Your profile has been updated.")).toBeInTheDocument()
+  })
+
+  it("renders all variants without crashing", () => {
     const variants = ["info", "success", "warning", "error"] as const
-    variants.forEach((v) => {
-      const { unmount } = render(<Alert variant={v} title={`${v} alert`} />)
-      expect(screen.getByText(`${v} alert`)).toBeInTheDocument()
-      unmount()
+    variants.forEach((variant) => {
+      render(<Alert variant={variant} title={`${variant} alert`} />)
+      expect(screen.getByText(`${variant} alert`)).toBeInTheDocument()
     })
   })
 
-  it("handles the dismissible toggle", () => {
-    const onDismiss = jest.fn()
-    render(<Alert title="Dismissible" onDismiss={onDismiss} />)
-    const button = screen.getByLabelText("Dismiss alert")
-    fireEvent.click(button)
-    expect(onDismiss).toHaveBeenCalledTimes(1)
+  it("removes itself from the DOM when dismissed", () => {
+    render(<Alert title="Dismiss me" dismissible />)
+    
+    const alertElement = screen.getByRole("alert")
+    expect(alertElement).toBeInTheDocument()
+    
+    const closeButton = screen.getByLabelText("Dismiss alert")
+    fireEvent.click(closeButton)
+    
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
   })
 
-  it("displays title and description in the correct layout", () => {
-    render(<Alert title="Alert Title" description="Detailed info here" />)
-    expect(screen.getByText("Alert Title")).toBeInTheDocument()
-    expect(screen.getByText("Detailed info here")).toBeInTheDocument()
+  it("does not render dismiss button if dismissible prop is false and onDismiss is omitted", () => {
+    render(<Alert title="Static Alert" />)
+    expect(screen.queryByLabelText("Dismiss alert")).not.toBeInTheDocument()
   })
 })

--- a/soroscan-frontend/components/ui/alert.tsx
+++ b/soroscan-frontend/components/ui/alert.tsx
@@ -1,10 +1,12 @@
+"use client"
+
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { AlertCircle, CheckCircle2, Info, XCircle, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm grid grid-cols-[auto_1fr_auto] gap-3 items-start [&>svg]:size-5",
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid grid-cols-[auto_1fr_auto] gap-3 items-start [&>svg]:size-5 transition-all",
   {
     variants: {
       variant: {
@@ -30,12 +32,21 @@ const variantIcons = {
 interface AlertProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof alertVariants> {
   title?: string
   description?: string
+  dismissible?: boolean
   onDismiss?: () => void
 }
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
-  ({ className, variant = "info", title, description, onDismiss, ...props }, ref) => {
+  ({ className, variant = "info", title, description, dismissible = false, onDismiss, ...props }, ref) => {
+    const [isVisible, setIsVisible] = React.useState(true)
     const Icon = variantIcons[variant || "info"]
+
+    const handleDismiss = () => {
+      setIsVisible(false)
+      if (onDismiss) onDismiss()
+    }
+
+    if (!isVisible) return null
 
     return (
       <div
@@ -44,15 +55,16 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
         className={cn(alertVariants({ variant }), className)}
         {...props}
       >
-        <Icon className="mt-0.5" aria-hidden="true" />
-        <div className="flex flex-col gap-1">
+        <Icon className="mt-0.5 shrink-0" aria-hidden="true" />
+        <div className="flex flex-col gap-1 flex-1">
           {title && <h5 className="font-semibold leading-none tracking-tight">{title}</h5>}
           {description && <div className="text-sm opacity-90">{description}</div>}
         </div>
-        {onDismiss && (
+        {(dismissible || onDismiss) && (
           <button
-            onClick={onDismiss}
-            className="p-1 rounded-md hover:bg-black/5 dark:hover:bg-white/10 transition-colors cursor-pointer"
+            type="button"
+            onClick={handleDismiss}
+            className="p-1 rounded-md hover:bg-black/5 dark:hover:bg-white/10 transition-colors cursor-pointer shrink-0"
             aria-label="Dismiss alert"
           >
             <X className="size-4" />


### PR DESCRIPTION
Closes #263

### **Description**
This PR introduces a reusable, accessible `Alert` component to the UI library for displaying system messages, warnings, and success states.

### **Changes**
* **New Component**: Updated `components/ui/alert.tsx` to handle internal state and use `lucide-react` for iconography.
* **Variants**: Mapped out color and icon variants (`info`, `success`, `warning`, `error`) using CVA.
* **Interactivity**: Added a `dismissible` prop leveraging local state to hide the alert and clean up the DOM without requiring parent-level state management.
* **Accessibility**: Implemented `role="alert"` and descriptive `aria-label` attributes on the close toggle.
* **Testing**: Created `__tests__/ui-alert.test.tsx` to verify variant rendering, title/description injection, and dismiss functionality. All tests pass.

### **Acceptance Criteria Progress**
- [x] Alert component supports 4 variants
- [x] Dismissible toggle works
- [x] Icons display correctly
- [x] Colors match design system
- [x] Tests verify all variants