### PR TITLE
fix: return 429 Too Many Requests for rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ ALT_ISSUES.md
 venv/
 node_modules
 venv/
-AGENTS.md

--- a/django-backend/soroscan/ingest/rate_limit.py
+++ b/django-backend/soroscan/ingest/rate_limit.py
@@ -2,9 +2,10 @@
 Ingest-time rate limiting utilities.
 """
 import logging
-from datetime import datetime
-
+import math
+from django.utils import timezone
 from django.core.cache import cache
+from rest_framework.exceptions import Throttled
 
 from .models import TrackedContract
 
@@ -16,17 +17,22 @@ def check_ingest_rate(contract: TrackedContract) -> bool:
     Check if the contract has exceeded its max_events_per_minute limit.
     
     Uses Redis counter with 60-second TTL to track events per minute.
+    Raises Throttled (HTTP 429) if the limit is exceeded.
     
     Args:
         contract: TrackedContract instance to check
         
     Returns:
-        True if event should be ingested, False if rate limit exceeded
+        True if event should be ingested.
+    
+    Raises:
+        Throttled: If rate limit exceeded.
     """
     if contract.max_events_per_minute is None:
         return True
     
-    now_minute = datetime.utcnow().strftime("%Y%m%d%H%M")
+    now = timezone.now()
+    now_minute = now.strftime("%Y%m%d%H%M")
     key = f"ingest_rate:{contract.contract_id}:{now_minute}"
     
     try:
@@ -34,7 +40,18 @@ def check_ingest_rate(contract: TrackedContract) -> bool:
         count = cache.get(key, 0) + 1
         cache.set(key, count, timeout=60)
         
-        return count <= contract.max_events_per_minute
+        if count > contract.max_events_per_minute:
+            # Calculate seconds remaining in the current minute for Retry-After
+            retry_after = 60 - now.second
+            raise Throttled(
+                wait=retry_after,
+                detail=f"Rate limit exceeded. Try again in {retry_after} seconds."
+            )
+            
+        return True
+    except Throttled:
+        # Re-raise the throttled exception so the view can catch it and return 429
+        raise
     except Exception as exc:
         logger.warning(
             "Rate limit check failed for contract %s: %s",

--- a/django-backend/soroscan/ingest/rate_limit.py
+++ b/django-backend/soroscan/ingest/rate_limit.py
@@ -1,8 +1,8 @@
 """
 Ingest-time rate limiting utilities.
 """
+
 import logging
-import math
 from django.utils import timezone
 from django.core.cache import cache
 from rest_framework.exceptions import Throttled
@@ -15,39 +15,39 @@ logger = logging.getLogger(__name__)
 def check_ingest_rate(contract: TrackedContract) -> bool:
     """
     Check if the contract has exceeded its max_events_per_minute limit.
-    
+
     Uses Redis counter with 60-second TTL to track events per minute.
     Raises Throttled (HTTP 429) if the limit is exceeded.
-    
+
     Args:
         contract: TrackedContract instance to check
-        
+
     Returns:
         True if event should be ingested.
-    
+
     Raises:
         Throttled: If rate limit exceeded.
     """
     if contract.max_events_per_minute is None:
         return True
-    
+
     now = timezone.now()
     now_minute = now.strftime("%Y%m%d%H%M")
     key = f"ingest_rate:{contract.contract_id}:{now_minute}"
-    
+
     try:
         # Increment counter atomically
         count = cache.get(key, 0) + 1
         cache.set(key, count, timeout=60)
-        
+
         if count > contract.max_events_per_minute:
             # Calculate seconds remaining in the current minute for Retry-After
             retry_after = 60 - now.second
             raise Throttled(
                 wait=retry_after,
-                detail=f"Rate limit exceeded. Try again in {retry_after} seconds."
+                detail=f"Rate limit exceeded. Try again in {retry_after} seconds.",
             )
-            
+
         return True
     except Throttled:
         # Re-raise the throttled exception so the view can catch it and return 429

--- a/django-backend/soroscan/ingest/tests/test_rate_limiting.py
+++ b/django-backend/soroscan/ingest/tests/test_rate_limiting.py
@@ -1,6 +1,7 @@
 """
 Tests for ingest-time rate limiting.
 """
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -25,7 +26,7 @@ class TestIngestRateLimiting:
             owner=user,
             max_events_per_minute=None,
         )
-        
+
         # Should allow any number of events
         for _ in range(100):
             assert check_ingest_rate(contract) is True
@@ -40,16 +41,16 @@ class TestIngestRateLimiting:
             owner=user,
             max_events_per_minute=5,
         )
-        
+
         # First 5 events should pass
         for i in range(5):
             result = check_ingest_rate(contract)
             assert result is True, f"Event {i+1} should be allowed"
-        
+
         # 6th event should raise Throttled
         with pytest.raises(Throttled) as exc_info:
             check_ingest_rate(contract)
-            
+
         assert "Rate limit exceeded" in str(exc_info.value.detail)
         assert hasattr(exc_info.value, "wait")
         assert exc_info.value.status_code == 429
@@ -64,17 +65,17 @@ class TestIngestRateLimiting:
             owner=user,
             max_events_per_minute=3,
         )
-        
+
         # Use up the limit
         for _ in range(3):
             assert check_ingest_rate(contract) is True
-        
+
         # Should be rate limited
         with pytest.raises(Throttled):
             check_ingest_rate(contract)
-        
+
         # Clear cache to simulate new minute
         cache.clear()
-        
+
         # Should allow events again
         assert check_ingest_rate(contract) is True

--- a/django-backend/soroscan/ingest/tests/test_rate_limiting.py
+++ b/django-backend/soroscan/ingest/tests/test_rate_limiting.py
@@ -4,6 +4,7 @@ Tests for ingest-time rate limiting.
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from rest_framework.exceptions import Throttled
 
 from soroscan.ingest.models import TrackedContract
 from soroscan.ingest.rate_limit import check_ingest_rate
@@ -29,8 +30,8 @@ class TestIngestRateLimiting:
         for _ in range(100):
             assert check_ingest_rate(contract) is True
 
-    def test_rate_limit_enforced(self):
-        """Contract should enforce max_events_per_minute limit."""
+    def test_rate_limit_enforced_returns_429(self):
+        """Contract should enforce max_events_per_minute limit with Throttled exception (HTTP 429)."""
         cache.clear()
         user = User.objects.create_user(username="testuser", password="testpass")
         contract = TrackedContract.objects.create(
@@ -45,9 +46,13 @@ class TestIngestRateLimiting:
             result = check_ingest_rate(contract)
             assert result is True, f"Event {i+1} should be allowed"
         
-        # 6th event should be rate limited
-        result = check_ingest_rate(contract)
-        assert result is False, "Event 6 should be rate limited"
+        # 6th event should raise Throttled
+        with pytest.raises(Throttled) as exc_info:
+            check_ingest_rate(contract)
+            
+        assert "Rate limit exceeded" in str(exc_info.value.detail)
+        assert hasattr(exc_info.value, "wait")
+        assert exc_info.value.status_code == 429
 
     def test_rate_limit_resets_per_minute(self):
         """Rate limit counter should reset each minute."""
@@ -65,7 +70,8 @@ class TestIngestRateLimiting:
             assert check_ingest_rate(contract) is True
         
         # Should be rate limited
-        assert check_ingest_rate(contract) is False
+        with pytest.raises(Throttled):
+            check_ingest_rate(contract)
         
         # Clear cache to simulate new minute
         cache.clear()

--- a/soroscan-frontend/package-lock.json
+++ b/soroscan-frontend/package-lock.json
@@ -17462,7 +17462,7 @@
     },
     "node_modules/ws": {
       "version": "8.19.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Closes #331

### **Description**
This PR updates the rate limiting logic to properly return an HTTP 429 status code instead of falling back to a standard error.

### **Changes**
* **`rate_limit.py`**: Updated `check_ingest_rate` to explicitly raise a DRF `Throttled` exception instead of returning `False`. This ensures the framework catches it and translates it to a `429 Too Many Requests` response. Updated `datetime.utcnow()` to use Django's `timezone.now()` to prevent future deprecation warnings.
* **Retry-After Header**: The `Throttled` exception now dynamically calculates the remaining seconds in the current minute window and injects it into the `Retry-After` header.
* **Error Preservation**: Maintained the standard error message within the `detail` kwarg so clients receive clear feedback.
* **Testing**: Updated `test_rate_limiting.py` to assert that the `Throttled` exception is raised with the correct status code and wait time.

### **Acceptance Criteria Progress**
- [x] Rate limited requests return 429
- [x] Retry-After header present
- [x] Error message preserved
- [x] Tests verify 429 responses