### PR TITLE
feat: log warning when celery task approaches timeout

### DIFF
--- a/django-backend/soroscan/ingest/tasks.py
+++ b/django-backend/soroscan/ingest/tasks.py
@@ -1,6 +1,8 @@
 """
 Celery tasks for SoroScan background processing.
 """
+
+import threading
 import cProfile
 import base64
 import hashlib
@@ -79,7 +81,9 @@ def _stop_task_profiling(task_id: str, task, **kwargs) -> None:
     elapsed = time.monotonic() - start
     if elapsed > _SLOW_TASK_THRESHOLD_S:
         stream = io.StringIO()
-        pstats.Stats(profiler, stream=stream).sort_stats(pstats.SortKey.CUMULATIVE).print_stats(20)
+        pstats.Stats(profiler, stream=stream).sort_stats(
+            pstats.SortKey.CUMULATIVE
+        ).print_stats(20)
         logger.warning(
             "Slow task %s took %.2fs\n%s",
             task.name,
@@ -88,22 +92,67 @@ def _stop_task_profiling(task_id: str, task, **kwargs) -> None:
             extra={"task_name": task.name, "total_time_s": round(elapsed, 3)},
         )
 
+
+# ---------------------------------------------------------------------------
+# Celery task timeout monitoring via signals — warns at 80% of timeout
+# ---------------------------------------------------------------------------
+_task_timeout_timers: dict[str, threading.Timer] = {}
+
+
+def _log_timeout_warning(task_name: str, remaining: float) -> None:
+    logger.warning(
+        "Task %s is approaching timeout. %.1f seconds remaining.",
+        task_name,
+        remaining,
+        extra={"task_name": task_name, "time_remaining": remaining},
+    )
+
+
+@task_prerun.connect
+def _start_timeout_monitor(task_id: str, task, **kwargs) -> None:
+    # Check request first, then task class for timeouts
+    timeout = (
+        getattr(task.request, "soft_time_limit", None)
+        or getattr(task.request, "time_limit", None)
+        or getattr(task, "soft_time_limit", None)
+        or getattr(task, "time_limit", None)
+    )
+
+    if timeout:
+        warning_delay = float(timeout) * 0.8
+        remaining = float(timeout) - warning_delay
+        timer = threading.Timer(
+            warning_delay, _log_timeout_warning, args=(task.name, remaining)
+        )
+        timer.daemon = True
+        _task_timeout_timers[task_id] = timer
+        timer.start()
+
+
+@task_postrun.connect
+def _stop_timeout_monitor(task_id: str, task, **kwargs) -> None:
+    timer = _task_timeout_timers.pop(task_id, None)
+    if timer:
+        timer.cancel()
+
+
 # ---------------------------------------------------------------------------
 # Backoff calculation for webhook retries
 # ---------------------------------------------------------------------------
 
+
 def calculate_backoff(attempt: int, strategy: str, base_seconds: int) -> int:
     """
     Calculate the backoff delay for a webhook retry attempt.
-    
+
     Args:
         attempt: 0-based attempt number (0 = first retry, 1 = second retry, etc.)
         strategy: One of 'exponential', 'linear', or 'fixed'
         base_seconds: Base number of seconds for the backoff calculation
-    
+
     Returns:
         Backoff delay in seconds
-        
+
     Examples:
         - exponential with base_seconds=60, attempt=2: 60 * 2^2 = 240 seconds
         - linear with base_seconds=60, attempt=2: 60 * 2 = 120 seconds
@@ -111,7 +160,7 @@ def calculate_backoff(attempt: int, strategy: str, base_seconds: int) -> int:
     """
     if strategy == "exponential":
         # base_seconds * 2^attempt
-        return base_seconds * (2 ** attempt)
+        return base_seconds * (2**attempt)
     elif strategy == "linear":
         # base_seconds * attempt (add 1 because attempt is 0-based)
         return base_seconds * (attempt + 1)
@@ -120,16 +169,19 @@ def calculate_backoff(attempt: int, strategy: str, base_seconds: int) -> int:
         return base_seconds
     else:
         # Default to exponential if unknown strategy
-        return base_seconds * (2 ** attempt)
+        return base_seconds * (2**attempt)
+
 
 # ---------------------------------------------------------------------------
 # Prometheus metrics (imported lazily to avoid import-time side-effects
 # during migrations/management commands that don't need metrics).
 # ---------------------------------------------------------------------------
 
+
 def _get_metrics():
     """Return the metrics module, importing it on first call."""
     from soroscan.ingest import metrics  # noqa: PLC0415
+
     return metrics
 
 
@@ -203,7 +255,9 @@ def _calculate_completeness(contract: TrackedContract) -> dict[str, Any]:
         previous = ledger
 
     completeness_percentage = (
-        100.0 if expected_ledgers == 0 else (observed_ledgers / expected_ledgers) * 100.0
+        100.0
+        if expected_ledgers == 0
+        else (observed_ledgers / expected_ledgers) * 100.0
     )
     return {
         "contract_id": contract.contract_id,
@@ -274,11 +328,17 @@ def _message_for_signature(event: Any, payload: dict[str, Any]) -> bytes:
         for k, v in payload.items()
         if k not in {"signature", "event_signature", "sig"}
     }
-    return json.dumps(signing_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return json.dumps(signing_payload, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
 
 
-def _build_webhook_signature_header(webhook: WebhookSubscription, payload_bytes: bytes) -> str:
-    algorithm = (webhook.signature_algorithm or WebhookSubscription.SIGNATURE_SHA256).lower()
+def _build_webhook_signature_header(
+    webhook: WebhookSubscription, payload_bytes: bytes
+) -> str:
+    algorithm = (
+        webhook.signature_algorithm or WebhookSubscription.SIGNATURE_SHA256
+    ).lower()
     if algorithm == WebhookSubscription.SIGNATURE_SHA1:
         digestmod = hashlib.sha1
         prefix = "sha1"
@@ -430,11 +490,13 @@ def _upsert_contract_event(
         )
         # Return a dummy tuple to indicate the event was skipped
         return (None, False)
-    
+
     ledger = _safe_int(_event_attr(event, "ledger", "ledger_sequence"), default=0)
     event_index = _extract_event_index(event, fallback_event_index)
     tx_hash = str(_event_attr(event, "tx_hash", "transaction_hash", default="") or "")
-    event_type = str(_event_attr(event, "type", "event_type", default="unknown") or "unknown")
+    event_type = str(
+        _event_attr(event, "type", "event_type", default="unknown") or "unknown"
+    )
 
     # Check whitelist/blacklist filter before persisting
     if not contract.should_ingest_event(event_type):
@@ -456,7 +518,9 @@ def _upsert_contract_event(
 
     payload = _event_attr(event, "value", "payload", default={}) or {}
 
-    if not validate_contract_payload_schema(contract, payload, event_type, ledger=ledger):
+    if not validate_contract_payload_schema(
+        contract, payload, event_type, ledger=ledger
+    ):
         m = _get_metrics()
         m.events_validation_failures_total.labels(
             contract_id=_short_contract_id(contract.contract_id),
@@ -496,7 +560,7 @@ def _upsert_contract_event(
     if created:
         # Invalidate event count cache
         invalidate_event_count_cache(contract.contract_id)
-        
+
         m = _get_metrics()
         m.events_ingested_total.labels(
             contract_id=_short_contract_id(contract.contract_id),
@@ -701,7 +765,15 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
 
         if status_code == 429:
             error_msg = "Rate limited by subscriber (429)"
-            _log_delivery_attempt(webhook, event, attempt_number, status_code, False, error_msg, payload_size)
+            _log_delivery_attempt(
+                webhook,
+                event,
+                attempt_number,
+                status_code,
+                False,
+                error_msg,
+                payload_size,
+            )
             attempt_logged = True
             _on_delivery_failure(webhook, self)
             m.webhook_deliveries_total.labels(status="rate_limited").inc()
@@ -713,12 +785,12 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
                     countdown = int(retry_after)
                 except (ValueError, TypeError):
                     pass
-            
+
             # Check if we've exhausted retries
             if self.request.retries >= self.max_retries:
                 # Final attempt — don't retry, let the HTTPError propagate
                 raise requests.HTTPError("Rate limited (429)", response=response)
-            
+
             # If no Retry-After header, use webhook's backoff strategy
             if countdown is None:
                 countdown = calculate_backoff(
@@ -735,7 +807,15 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
         success = 200 <= status_code < 300
         error_msg = "" if success else f"HTTP {status_code}"
 
-        _log_delivery_attempt(webhook, event, attempt_number, status_code, success, error_msg, payload_size)
+        _log_delivery_attempt(
+            webhook,
+            event,
+            attempt_number,
+            status_code,
+            success,
+            error_msg,
+            payload_size,
+        )
         attempt_logged = True
 
         if success:
@@ -763,7 +843,15 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
     except requests.exceptions.Timeout:
         # Log timeout as 504 Gateway Timeout
         if not attempt_logged:
-            _log_delivery_attempt(webhook, event, attempt_number, 504, False, "Timeout exceeded", payload_size)
+            _log_delivery_attempt(
+                webhook,
+                event,
+                attempt_number,
+                504,
+                False,
+                "Timeout exceeded",
+                payload_size,
+            )
             attempt_logged = True
             _on_delivery_failure(webhook, self)
 
@@ -775,12 +863,12 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
             webhook.timeout_seconds,
             extra={"webhook_id": subscription_id},
         )
-        
+
         # Check if we've exhausted retries
         if self.request.retries >= self.max_retries:
             # Final attempt — don't retry, let the exception propagate
             raise
-        
+
         # Retry with backoff based on webhook's strategy
         countdown = calculate_backoff(
             self.request.retries,
@@ -791,7 +879,9 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
 
     except requests.RequestException as exc:
         if not attempt_logged:
-            _log_delivery_attempt(webhook, event, attempt_number, None, False, str(exc), payload_size)
+            _log_delivery_attempt(
+                webhook, event, attempt_number, None, False, str(exc), payload_size
+            )
             _on_delivery_failure(webhook, self)
         m.webhook_deliveries_total.labels(status="failure").inc()
         m.webhook_delivery_duration_seconds.observe(time.monotonic() - _start)
@@ -807,12 +897,12 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
             exc,
             extra={"webhook_id": subscription_id},
         )
-        
+
         # Check if we've exhausted retries
         if self.request.retries >= self.max_retries:
             # Final attempt — don't retry, let the exception propagate
             raise
-        
+
         # Retry with backoff based on webhook's strategy
         countdown = calculate_backoff(
             self.request.retries,
@@ -831,6 +921,7 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
 # ---------------------------------------------------------------------------
 # Private helpers for dispatch_webhook
 # ---------------------------------------------------------------------------
+
 
 def _log_delivery_attempt(
     webhook: WebhookSubscription,
@@ -882,6 +973,7 @@ def _on_delivery_failure(
         # Push in-app notification to the contract owner
         try:
             from .services.notifications import create_and_push
+
             owner = webhook.contract.owner
             create_and_push(
                 user=owner,
@@ -895,7 +987,10 @@ def _on_delivery_failure(
                 link=f"/webhooks/{webhook.id}",
             )
         except Exception:
-            logger.exception("Failed to create webhook_failure notification for webhook %s", webhook.id)
+            logger.exception(
+                "Failed to create webhook_failure notification for webhook %s",
+                webhook.id,
+            )
 
 
 @shared_task
@@ -923,10 +1018,10 @@ def cleanup_webhook_delivery_logs() -> int:
 def cleanup_old_dedup_logs(dry_run: bool = False) -> int:
     """
     Prune ``EventDeduplicationLog`` entries older than the configured retention period (TTL cleanup).
-    
+
     Args:
         dry_run: If True, calculate count but don't delete records.
-    
+
     Returns:
         Number of records that were (or would be) deleted.
     """
@@ -936,21 +1031,25 @@ def cleanup_old_dedup_logs(dry_run: bool = False) -> int:
     _start = time.monotonic()
     retention_days = getattr(settings, "DEDUP_LOG_RETENTION_DAYS", 90)
     cutoff = timezone.now() - timedelta(days=retention_days)
-    
+
     # Get the count of records that would be deleted
     records_to_delete = EventDeduplicationLog.objects.filter(created_at__lt=cutoff)
     deleted_count = records_to_delete.count()
-    
+
     if not dry_run:
         # Actually delete the records
         deleted_count, _ = records_to_delete.delete()
-    
+
     logger.info(
         "Pruned %d EventDeduplicationLog entries older than %d days (dry_run=%s)",
         deleted_count,
         retention_days,
         dry_run,
-        extra={"deletion_count": deleted_count, "retention_days": retention_days, "dry_run": dry_run},
+        extra={
+            "deletion_count": deleted_count,
+            "retention_days": retention_days,
+            "dry_run": dry_run,
+        },
     )
     _get_metrics().task_duration_seconds.labels(
         task_name="cleanup_old_dedup_logs"
@@ -994,9 +1093,7 @@ def process_new_event(event_data: dict[str, Any]) -> None:
         contract__contract_id=contract_id,
         is_active=True,
         status=WebhookSubscription.STATUS_ACTIVE,
-    ).filter(
-        event_type__in=[event_type, ""]
-    )
+    ).filter(event_type__in=[event_type, ""])
 
     # CDC streaming should not depend on webhook subscriptions.
     producer = get_producer()
@@ -1004,7 +1101,9 @@ def process_new_event(event_data: dict[str, Any]) -> None:
         try:
             producer.publish(contract_id, event_data)
         except Exception:
-            logger.exception("Failed to stream event to backend", extra={"contract_id": contract_id})
+            logger.exception(
+                "Failed to stream event to backend", extra={"contract_id": contract_id}
+            )
 
     if not webhooks.exists():
         logger.info(
@@ -1077,7 +1176,7 @@ def analyze_contract_dependencies() -> dict[str, int]:
     """
     _start = time.monotonic()
     m = _get_metrics()
-    
+
     # We only care about invocations where the caller is a contract (starts with 'C')
     # and the target contract is also tracked.
     invocations = ContractInvocation.objects.filter(
@@ -1099,9 +1198,9 @@ def analyze_contract_dependencies() -> dict[str, int]:
         dependency, created = ContractDependency.objects.get_or_create(
             caller=caller_contract,
             callee=invocation.contract,
-            defaults={"call_count": 1}
+            defaults={"call_count": 1},
         )
-        
+
         if created:
             dependencies_created += 1
         else:
@@ -1110,15 +1209,17 @@ def analyze_contract_dependencies() -> dict[str, int]:
             dependencies_updated += 1
 
     duration = time.monotonic() - _start
-    m.task_duration_seconds.labels(task_name="analyze_contract_dependencies").observe(duration)
-    
+    m.task_duration_seconds.labels(task_name="analyze_contract_dependencies").observe(
+        duration
+    )
+
     logger.info(
         "Analyzed contract dependencies: created=%d, updated=%d in %.2fs",
         dependencies_created,
         dependencies_updated,
         duration,
     )
-    
+
     return {
         "created": dependencies_created,
         "updated": dependencies_updated,
@@ -1133,7 +1234,7 @@ def recompute_call_graph(contract_id: str | None = None) -> bool:
     Re-computes every hour (scheduled via Celery Beat).
     """
     _start = time.monotonic()
-    
+
     # Get all dependencies
     deps = ContractDependency.objects.select_related("caller", "callee").all()
     if contract_id:
@@ -1180,7 +1281,14 @@ def recompute_call_graph(contract_id: str | None = None) -> bool:
     # Prepare graph data for JSON storage
     graph_data = {
         "nodes": [{"id": n, "label": n[:8]} for n in nodes],
-        "edges": [{"from": d.caller.contract_id, "to": d.callee.contract_id, "weight": d.call_count} for d in deps],
+        "edges": [
+            {
+                "from": d.caller.contract_id,
+                "to": d.callee.contract_id,
+                "weight": d.call_count,
+            }
+            for d in deps
+        ],
     }
 
     # Update cache
@@ -1194,7 +1302,7 @@ def recompute_call_graph(contract_id: str | None = None) -> bool:
             "graph_data": graph_data,
             "has_cycles": has_cycles,
             "cycle_details": cycles if has_cycles else None,
-        }
+        },
     )
 
     logger.info(
@@ -1203,7 +1311,7 @@ def recompute_call_graph(contract_id: str | None = None) -> bool:
         len(deps),
         has_cycles,
     )
-    
+
     return True
 
 
@@ -1227,7 +1335,9 @@ def ingest_latest_events() -> int:
 
     try:
         contract_ids = list(
-            TrackedContract.objects.filter(is_active=True).values_list("contract_id", flat=True)
+            TrackedContract.objects.filter(is_active=True).values_list(
+                "contract_id", flat=True
+            )
         )
 
         # Always update the gauge, even when there are no active contracts.
@@ -1259,7 +1369,9 @@ def ingest_latest_events() -> int:
                 contract = TrackedContract.objects.get(contract_id=event.contract_id)
             except TrackedContract.DoesNotExist:
                 m.events_skipped_total.labels(
-                    contract_id=_short_contract_id(getattr(event, "contract_id", "") or ""),
+                    contract_id=_short_contract_id(
+                        getattr(event, "contract_id", "") or ""
+                    ),
                     network=network,
                     reason="no_contract",
                 ).inc()
@@ -1291,7 +1403,10 @@ def ingest_latest_events() -> int:
                     event.type,
                     contract.event_filter_type,
                     contract.contract_id,
-                    extra={"contract_id": contract.contract_id, "event_type": event.type},
+                    extra={
+                        "contract_id": contract.contract_id,
+                        "event_type": event.type,
+                    },
                 )
                 continue
 
@@ -1332,7 +1447,7 @@ def ingest_latest_events() -> int:
                 # Use cached client if available, or create new one
                 if client is None:
                     client = SorobanClient()
-                
+
                 invocation_data = client.get_invocation(event.tx_hash)
                 if invocation_data.success:
                     invocation_record, _ = ContractInvocation.objects.get_or_create(
@@ -1344,13 +1459,13 @@ def ingest_latest_events() -> int:
                             "parameters": invocation_data.parameters,
                             "result": invocation_data.result,
                             "ledger_sequence": event.ledger,
-                        }
+                        },
                     )
             except Exception:
                 logger.warning(
                     "Failed to create invocation record for tx=%s",
                     event.tx_hash,
-                    exc_info=True
+                    exc_info=True,
                 )
 
             event_record, created = ContractEvent.objects.get_or_create(
@@ -1379,7 +1494,13 @@ def ingest_latest_events() -> int:
                     event_record.validation_status = validation_status
                     event_record.schema_version = schema_version
                     event_record.signature_status = signature_status
-                    event_record.save(update_fields=["validation_status", "schema_version", "signature_status"])
+                    event_record.save(
+                        update_fields=[
+                            "validation_status",
+                            "schema_version",
+                            "signature_status",
+                        ]
+                    )
 
             if created:
                 new_events += 1
@@ -1399,7 +1520,10 @@ def ingest_latest_events() -> int:
                     }
                 )
 
-            if contract.last_indexed_ledger is None or event_record.ledger > contract.last_indexed_ledger:
+            if (
+                contract.last_indexed_ledger is None
+                or event_record.ledger > contract.last_indexed_ledger
+            ):
                 if (
                     contract.last_indexed_ledger is not None
                     and event_record.ledger > contract.last_indexed_ledger + 1
@@ -1441,9 +1565,9 @@ def ingest_latest_events() -> int:
 
     finally:
         # Always record duration, even if an exception occurred.
-        m.task_duration_seconds.labels(
-            task_name="ingest_latest_events"
-        ).observe(time.monotonic() - _start)
+        m.task_duration_seconds.labels(task_name="ingest_latest_events").observe(
+            time.monotonic() - _start
+        )
 
     return new_events
 
@@ -1455,22 +1579,22 @@ def aggregate_event_statistics() -> dict[str, Any]:
     """
     _start = time.monotonic()
     m = _get_metrics()
-    
+
     # Placeholder for actual aggregation logic
     total_events = ContractEvent.objects.count()
     active_contracts = TrackedContract.objects.filter(is_active=True).count()
-    
+
     logger.info(
         "Aggregated statistics: %d events across %d contracts",
         total_events,
         active_contracts,
         extra={"total_events": total_events, "active_contracts": active_contracts},
     )
-    
-    m.task_duration_seconds.labels(
-        task_name="aggregate_event_statistics"
-    ).observe(time.monotonic() - _start)
-    
+
+    m.task_duration_seconds.labels(task_name="aggregate_event_statistics").observe(
+        time.monotonic() - _start
+    )
+
     return {
         "total_events": total_events,
         "active_contracts": active_contracts,
@@ -1498,12 +1622,12 @@ def reconcile_event_completeness() -> dict[str, Any]:
         )
 
         if summary["missing_ledgers"] > 0:
-            m.ledger_gaps_total.labels(contract_id=_short_contract_id(contract.contract_id)).inc(
-                len(summary["gaps"])
-            )
-            m.missing_events_total.labels(contract_id=_short_contract_id(contract.contract_id)).inc(
-                summary["missing_ledgers"]
-            )
+            m.ledger_gaps_total.labels(
+                contract_id=_short_contract_id(contract.contract_id)
+            ).inc(len(summary["gaps"]))
+            m.missing_events_total.labels(
+                contract_id=_short_contract_id(contract.contract_id)
+            ).inc(summary["missing_ledgers"])
             for gap in summary["gaps"][:10]:
                 backfill_contract_events.delay(
                     contract.contract_id,
@@ -1565,7 +1689,9 @@ def backfill_contract_events(
         for batch_start in range(next_ledger, end_ledger + 1, BATCH_LEDGER_SIZE):
             batch_end = min(batch_start + BATCH_LEDGER_SIZE - 1, end_ledger)
             _batch_start_time = time.monotonic()
-            batch_events = client.get_events_range(contract.contract_id, batch_start, batch_end)
+            batch_events = client.get_events_range(
+                contract.contract_id, batch_start, batch_end
+            )
 
             # Create batch_cache for this batch to avoid redundant RPC calls
             batch_cache = {}
@@ -1580,7 +1706,11 @@ def backfill_contract_events(
 
             for fallback_event_index, event in enumerate(batch_events):
                 result = _upsert_contract_event(
-                    contract, event, fallback_event_index, client=client, batch_cache=batch_cache
+                    contract,
+                    event,
+                    fallback_event_index,
+                    client=client,
+                    batch_cache=batch_cache,
                 )
                 # Handle rate-limited events (returns None, False)
                 if result[0] is None:
@@ -1597,7 +1727,9 @@ def backfill_contract_events(
 
             # Record per-batch metrics.
             ledger_span = batch_end - batch_start + 1
-            m.backfill_ledgers_processed_total.labels(contract_id=short_cid).inc(ledger_span)
+            m.backfill_ledgers_processed_total.labels(contract_id=short_cid).inc(
+                ledger_span
+            )
             m.backfill_batch_duration_seconds.labels(contract_id=short_cid).observe(
                 time.monotonic() - _batch_start_time
             )
@@ -1630,9 +1762,9 @@ def backfill_contract_events(
         raise self.retry(exc=exc)
     finally:
         # Always record duration, even if an exception occurred.
-        m.task_duration_seconds.labels(
-            task_name="backfill_contract_events"
-        ).observe(time.monotonic() - _start)
+        m.task_duration_seconds.labels(task_name="backfill_contract_events").observe(
+            time.monotonic() - _start
+        )
 
 
 @shared_task(bind=True, queue="backfill")
@@ -1671,6 +1803,7 @@ def reprocess_events(
 # Issue: Event-driven alerts — condition evaluator and dispatch tasks
 # ---------------------------------------------------------------------------
 
+
 def _get_field(data: dict, dotted_path: str):
     """Traverse a dot-notation path through nested dicts."""
     current = data
@@ -1708,21 +1841,34 @@ def evaluate_condition(condition: dict, event_data: dict) -> bool:
     current = _get_field(event_data, field)
 
     if op == "eq":
-        return str(current) == str(value) if current is not None else str(None) == str(value)
+        return (
+            str(current) == str(value)
+            if current is not None
+            else str(None) == str(value)
+        )
     if op == "neq":
         return str(current) != str(value)
     if op in ("gt", "gte", "lt", "lte"):
         try:
             lhs, rhs = float(str(current)), float(str(value))
-            return {"gt": lhs > rhs, "gte": lhs >= rhs, "lt": lhs < rhs, "lte": lhs <= rhs}[op]
+            return {
+                "gt": lhs > rhs,
+                "gte": lhs >= rhs,
+                "lt": lhs < rhs,
+                "lte": lhs <= rhs,
+            }[op]
         except (TypeError, ValueError):
             return False
     if op == "contains":
-        return str(value).lower() in str(current).lower() if current is not None else False
+        return (
+            str(value).lower() in str(current).lower() if current is not None else False
+        )
     if op == "startswith":
         return str(current).startswith(str(value)) if current is not None else False
     if op == "in":
-        return current in value if isinstance(value, list) else str(current) == str(value)
+        return (
+            current in value if isinstance(value, list) else str(current) == str(value)
+        )
     if op == "regex":
         if current is None:
             return False
@@ -1773,7 +1919,9 @@ def send_alert(self, rule_id: int, event_id: int) -> str:
     from .models import AlertRule, AlertExecution
 
     try:
-        rule = AlertRule.objects.select_related("contract").get(id=rule_id, is_active=True)
+        rule = AlertRule.objects.select_related("contract").get(
+            id=rule_id, is_active=True
+        )
     except AlertRule.DoesNotExist:
         return "skipped:rule_gone"
 
@@ -1814,7 +1962,11 @@ def send_alert(self, rule_id: int, event_id: int) -> str:
             else:
                 raise ValueError(f"Unknown action_type: {action_type}")
             AlertExecution.objects.create(
-                rule=rule, event=event, status="sent", response="ok", channel=action_type
+                rule=rule,
+                event=event,
+                status="sent",
+                response="ok",
+                channel=action_type,
             )
             successes += 1
         except Exception as exc:
@@ -1920,7 +2072,9 @@ def evaluate_alert_rules(event_id: int) -> int:
     rules = AlertRule.objects.filter(
         contract=event.contract,
         is_active=True,
-    ).order_by("id")[:AlertRule.MAX_RULES_PER_CONTRACT]
+    ).order_by(
+        "id"
+    )[: AlertRule.MAX_RULES_PER_CONTRACT]
 
     event_data = {
         "event_type": event.event_type,
@@ -1948,7 +2102,9 @@ def evaluate_alert_rules(event_id: int) -> int:
                 m.alert_rules_evaluated_total.labels(outcome="no_match").inc()
         except Exception:
             logger.exception(
-                "Error evaluating condition for rule %s", rule.id, extra={"rule_id": rule.id}
+                "Error evaluating condition for rule %s",
+                rule.id,
+                extra={"rule_id": rule.id},
             )
 
     return matched
@@ -1958,14 +2114,21 @@ def evaluate_alert_rules(event_id: int) -> int:
 # Automated incident response (remediation)
 # ---------------------------------------------------------------------------
 
-def _send_ops_alert(alert_type: str, target: str, message: str, payload: dict[str, Any]) -> None:
+
+def _send_ops_alert(
+    alert_type: str, target: str, message: str, payload: dict[str, Any]
+) -> None:
     if not target:
         logger.warning("Remediation alert target is empty; skipping alert")
         return
 
     if alert_type == RemediationRule.ALERT_SLACK:
         timeout = getattr(settings, "SLACK_ALERT_TIMEOUT_SECONDS", 10)
-        resp = requests.post(target, json={"text": f"{message}\n```{json.dumps(payload, indent=2)[:1500]}```"}, timeout=timeout)
+        resp = requests.post(
+            target,
+            json={"text": f"{message}\n```{json.dumps(payload, indent=2)[:1500]}```"},
+            timeout=timeout,
+        )
         resp.raise_for_status()
         return
 
@@ -1982,7 +2145,9 @@ def _send_ops_alert(alert_type: str, target: str, message: str, payload: dict[st
         return
 
     if alert_type == RemediationRule.ALERT_WEBHOOK:
-        resp = requests.post(target, json={"message": message, "payload": payload}, timeout=10)
+        resp = requests.post(
+            target, json={"message": message, "payload": payload}, timeout=10
+        )
         resp.raise_for_status()
         return
 
@@ -1996,7 +2161,9 @@ def _resolve_contract_for_rule(rule: RemediationRule) -> TrackedContract | None:
     return TrackedContract.objects.filter(contract_id=contract_id).first()
 
 
-def _detect_anomaly(rule: RemediationRule, contract: TrackedContract) -> tuple[bool, dict[str, Any]]:
+def _detect_anomaly(
+    rule: RemediationRule, contract: TrackedContract
+) -> tuple[bool, dict[str, Any]]:
     condition = rule.condition or {}
     condition_type = condition.get("type")
     now = timezone.now()
@@ -2004,8 +2171,13 @@ def _detect_anomaly(rule: RemediationRule, contract: TrackedContract) -> tuple[b
     if condition_type == RemediationRule.CONDITION_NO_EVENTS:
         minutes = int(condition.get("minutes", 60))
         cutoff = now - timedelta(minutes=minutes)
-        has_recent = ContractEvent.objects.filter(contract=contract, timestamp__gte=cutoff).exists()
-        return (not has_recent, {"type": condition_type, "minutes": minutes, "cutoff": cutoff.isoformat()})
+        has_recent = ContractEvent.objects.filter(
+            contract=contract, timestamp__gte=cutoff
+        ).exists()
+        return (
+            not has_recent,
+            {"type": condition_type, "minutes": minutes, "cutoff": cutoff.isoformat()},
+        )
 
     if condition_type == RemediationRule.CONDITION_DECODE_ERROR_SPIKE:
         window_minutes = int(condition.get("window_minutes", 60))
@@ -2043,7 +2215,11 @@ def _execute_remediation_actions(
 
     for action in incident.rule.actions or []:
         action_type = (action or {}).get("type")
-        entry: dict[str, Any] = {"type": action_type, "dry_run": effective_dry_run, "status": "skipped"}
+        entry: dict[str, Any] = {
+            "type": action_type,
+            "dry_run": effective_dry_run,
+            "status": "skipped",
+        }
 
         if action_type == "pause_contract":
             if not effective_dry_run:
@@ -2053,7 +2229,9 @@ def _execute_remediation_actions(
 
         elif action_type == "disable_webhooks":
             if not effective_dry_run:
-                disabled = WebhookSubscription.objects.filter(contract=incident.contract, is_active=True).update(
+                disabled = WebhookSubscription.objects.filter(
+                    contract=incident.contract, is_active=True
+                ).update(
                     is_active=False,
                     status=WebhookSubscription.STATUS_SUSPENDED,
                 )
@@ -2124,7 +2302,10 @@ def evaluate_remediation_rules(dry_run: bool = False) -> dict[str, Any]:
             RemediationIncident.objects.filter(
                 rule=rule,
                 contract=contract,
-                status__in=[RemediationIncident.STATUS_ALERTED, RemediationIncident.STATUS_EXECUTED],
+                status__in=[
+                    RemediationIncident.STATUS_ALERTED,
+                    RemediationIncident.STATUS_EXECUTED,
+                ],
                 resolved_at__isnull=True,
             )
             .order_by("-first_detected_at")
@@ -2132,10 +2313,15 @@ def evaluate_remediation_rules(dry_run: bool = False) -> dict[str, Any]:
         )
 
         if not triggered:
-            if open_incident and open_incident.status != RemediationIncident.STATUS_RESOLVED:
+            if (
+                open_incident
+                and open_incident.status != RemediationIncident.STATUS_RESOLVED
+            ):
                 open_incident.status = RemediationIncident.STATUS_RESOLVED
                 open_incident.resolved_at = now
-                open_incident.save(update_fields=["status", "resolved_at", "last_seen_at"])
+                open_incident.save(
+                    update_fields=["status", "resolved_at", "last_seen_at"]
+                )
                 AdminAction.objects.create(
                     user=None,
                     action="remediation_resolved",
@@ -2167,7 +2353,11 @@ def evaluate_remediation_rules(dry_run: bool = False) -> dict[str, Any]:
             try:
                 _send_ops_alert(rule.alert_type, rule.alert_target, message, snapshot)
             except Exception:
-                logger.warning("Failed to send remediation pre-alert for rule=%s", rule.id, exc_info=True)
+                logger.warning(
+                    "Failed to send remediation pre-alert for rule=%s",
+                    rule.id,
+                    exc_info=True,
+                )
 
             AdminAction.objects.create(
                 user=None,
@@ -2193,12 +2383,16 @@ def evaluate_remediation_rules(dry_run: bool = False) -> dict[str, Any]:
             continue
 
         effective_dry_run = dry_run or rule.dry_run
-        executed = _execute_remediation_actions(open_incident, effective_dry_run=effective_dry_run)
+        executed = _execute_remediation_actions(
+            open_incident, effective_dry_run=effective_dry_run
+        )
 
         open_incident.status = RemediationIncident.STATUS_EXECUTED
         open_incident.executed_at = now
         open_incident.anomaly_snapshot = snapshot
-        open_incident.save(update_fields=["status", "executed_at", "anomaly_snapshot", "last_seen_at"])
+        open_incident.save(
+            update_fields=["status", "executed_at", "anomaly_snapshot", "last_seen_at"]
+        )
 
         AdminAction.objects.create(
             user=None,
@@ -2247,7 +2441,13 @@ def _upload_to_s3(bucket: str, key: str, data: bytes) -> int:
         aws_access_key_id=getattr(settings, "AWS_ACCESS_KEY_ID", None),
         aws_secret_access_key=getattr(settings, "AWS_SECRET_ACCESS_KEY", None),
     )
-    s3.put_object(Bucket=bucket, Key=key, Body=data, ContentEncoding="gzip", ContentType="application/json")
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=data,
+        ContentEncoding="gzip",
+        ContentType="application/json",
+    )
     return len(data)
 
 
@@ -2267,8 +2467,15 @@ def _export_batch_to_s3(
 
     rows = list(
         events_qs.values(
-            "id", "contract__contract_id", "event_type", "payload",
-            "payload_hash", "ledger", "event_index", "timestamp", "tx_hash",
+            "id",
+            "contract__contract_id",
+            "event_type",
+            "payload",
+            "payload_hash",
+            "ledger",
+            "event_index",
+            "timestamp",
+            "tx_hash",
         )
     )
     if not rows:
@@ -2291,9 +2498,7 @@ def _export_batch_to_s3(
             len(compressed),
         )
 
-    contract_slug = (
-        policy.contract.contract_id[:12] if policy.contract else "global"
-    )
+    contract_slug = policy.contract.contract_id[:12] if policy.contract else "global"
     key = (
         f"{policy.s3_prefix.rstrip('/')}/{contract_slug}/"
         f"batch_{policy.id}_{batch_index}_{int(timezone.now().timestamp())}.json.gz"
@@ -2311,8 +2516,12 @@ def _export_batch_to_s3(
         s3_key=key,
         event_count=len(rows),
         size_bytes=size_bytes,
-        min_timestamp=parse_datetime(timestamps_sorted[0]) if timestamps_sorted else None,
-        max_timestamp=parse_datetime(timestamps_sorted[-1]) if timestamps_sorted else None,
+        min_timestamp=(
+            parse_datetime(timestamps_sorted[0]) if timestamps_sorted else None
+        ),
+        max_timestamp=(
+            parse_datetime(timestamps_sorted[-1]) if timestamps_sorted else None
+        ),
     )
 
     ArchivalAuditLog.objects.create(
@@ -2342,7 +2551,9 @@ def archive_old_events() -> dict:
     total_deleted = 0
     errors = []
 
-    policies = DataRetentionPolicy.objects.filter(archive_enabled=True).select_related("contract")
+    policies = DataRetentionPolicy.objects.filter(archive_enabled=True).select_related(
+        "contract"
+    )
 
     for policy in policies:
         try:
@@ -2362,7 +2573,9 @@ def archive_old_events() -> dict:
                 archived_ids = list(
                     base_qs.order_by("timestamp").values_list("id", flat=True)[:10000]
                 )
-                deleted_count, _ = ContractEvent.objects.filter(id__in=archived_ids).delete()
+                deleted_count, _ = ContractEvent.objects.filter(
+                    id__in=archived_ids
+                ).delete()
                 total_archived += batch.event_count
                 total_deleted += deleted_count
                 batch_index += 1
@@ -2432,6 +2645,7 @@ def cleanup_silk_data() -> int:
 # Issue #280: GDPR Data Governance — retention enforcement & deletion requests
 # ---------------------------------------------------------------------------
 
+
 @shared_task
 def enforce_retention_policies() -> dict[str, int]:
     """
@@ -2460,10 +2674,14 @@ def enforce_retention_policies() -> dict[str, int]:
         if days is None:
             continue
         cutoff = now - timedelta(days=days)
-        deleted, _ = ContractEvent.objects.filter(contract_id=contract_pk, timestamp__lt=cutoff).delete()
+        deleted, _ = ContractEvent.objects.filter(
+            contract_id=contract_pk, timestamp__lt=cutoff
+        ).delete()
         if deleted:
             summary[contract_id] = deleted
-            logger.info("Retention: deleted %d events for contract %s", deleted, contract_id)
+            logger.info(
+                "Retention: deleted %d events for contract %s", deleted, contract_id
+            )
 
     return summary
 
@@ -2477,7 +2695,9 @@ def process_deletion_requests() -> dict[str, Any]:
     """
     from .models import DataDeletionRequest, PIIField, AuditLog
 
-    pending = DataDeletionRequest.objects.filter(status=DataDeletionRequest.STATUS_PENDING)
+    pending = DataDeletionRequest.objects.filter(
+        status=DataDeletionRequest.STATUS_PENDING
+    )
     results: dict[str, Any] = {}
 
     for req in pending:
@@ -2486,7 +2706,11 @@ def process_deletion_requests() -> dict[str, Any]:
         total_deleted = 0
         try:
             # Determine scope: specific contracts or all
-            contract_qs = req.contracts.all() if req.contracts.exists() else TrackedContract.objects.all()
+            contract_qs = (
+                req.contracts.all()
+                if req.contracts.exists()
+                else TrackedContract.objects.all()
+            )
 
             for contract in contract_qs:
                 pii_fields = PIIField.objects.filter(contract=contract)
@@ -2526,9 +2750,15 @@ def process_deletion_requests() -> dict[str, Any]:
                 action=AuditLog.ACTION_DELETE,
                 model_name="DataDeletionRequest",
                 object_id=str(req.pk),
-                changes={"subject_identifier": req.subject_identifier, "events_scrubbed": total_deleted},
+                changes={
+                    "subject_identifier": req.subject_identifier,
+                    "events_scrubbed": total_deleted,
+                },
             )
-            results[str(req.pk)] = {"status": "completed", "events_deleted": total_deleted}
+            results[str(req.pk)] = {
+                "status": "completed",
+                "events_deleted": total_deleted,
+            }
         except Exception as exc:
             req.status = DataDeletionRequest.STATUS_FAILED
             req.error_message = str(exc)
@@ -2542,6 +2772,7 @@ def process_deletion_requests() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Issue #284: Contract upgrade detection
 # ---------------------------------------------------------------------------
+
 
 @shared_task
 def detect_contract_upgrades() -> dict[str, Any]:

--- a/django-backend/soroscan/ingest/tests/test_celery_timeout.py
+++ b/django-backend/soroscan/ingest/tests/test_celery_timeout.py
@@ -1,0 +1,67 @@
+"""
+Tests for Celery task timeout monitoring.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from soroscan.ingest.tasks import (
+    _log_timeout_warning,
+    _start_timeout_monitor,
+    _stop_timeout_monitor,
+    _task_timeout_timers,
+)
+
+
+def test_timeout_monitor_lifecycle():
+    """Ensure timer starts at 80% and cancels on completion."""
+    task_mock = MagicMock()
+    task_mock.name = "test.slow_task"
+    task_mock.soft_time_limit = 100
+    task_mock.time_limit = None
+    task_mock.request.soft_time_limit = None
+    task_mock.request.time_limit = None
+
+    with patch("soroscan.ingest.tasks.threading.Timer") as mock_timer_class:
+        mock_timer_instance = MagicMock()
+        mock_timer_class.return_value = mock_timer_instance
+
+        # Simulate task start
+        _start_timeout_monitor(task_id="task-123", task=task_mock)
+
+        # Timer should be set for 80 seconds (80% of 100s) with 20s remaining
+        mock_timer_class.assert_called_once_with(
+            80.0, _log_timeout_warning, args=("test.slow_task", 20.0)
+        )
+        mock_timer_instance.start.assert_called_once()
+        assert "task-123" in _task_timeout_timers
+
+        # Simulate task finish
+        _stop_timeout_monitor(task_id="task-123", task=task_mock)
+
+        mock_timer_instance.cancel.assert_called_once()
+        assert "task-123" not in _task_timeout_timers
+
+
+def test_timeout_monitor_no_timeout():
+    """Ensure no timer is created if task has no timeout."""
+    task_mock = MagicMock()
+    task_mock.name = "test.fast_task"
+    task_mock.soft_time_limit = None
+    task_mock.time_limit = None
+    task_mock.request.soft_time_limit = None
+    task_mock.request.time_limit = None
+
+    with patch("soroscan.ingest.tasks.threading.Timer") as mock_timer_class:
+        _start_timeout_monitor(task_id="task-456", task=task_mock)
+        mock_timer_class.assert_not_called()
+        assert "task-456" not in _task_timeout_timers
+
+
+def test_log_timeout_warning(caplog):
+    """Verify the warning log contains task name and remaining time."""
+    with caplog.at_level(logging.WARNING):
+        _log_timeout_warning("test.slow_task", 15.5)
+
+    assert "Task test.slow_task is approaching timeout" in caplog.text
+    assert "15.5 seconds remaining" in caplog.text


### PR DESCRIPTION
Closes #337

### **Description**
This PR introduces global timeout monitoring for Celery tasks. Instead of tasks silently failing upon hitting hard timeouts, this alerts operations by logging a warning when a task reaches 80% of its allowed execution time.

### **Changes**
* **Signals Integration**: Hooked into `task_prerun` and `task_postrun` in `tasks.py` to transparently wrap all existing and future celery tasks without boilerplate.
* **Non-blocking Timer**: Leveraged `threading.Timer` to calculate 80% of the active `time_limit` / `soft_time_limit` and trigger the logging callback. Timers are cleanly canceled when tasks complete successfully.
* **Logging Details**: Injects the task name and the precise seconds remaining into the logger context.
* **Testing**: Added `test_celery_timeout.py` to verify the math logic and lifecycle hooks using mocked `threading.Timers` to keep test execution fast and deterministic.

### **Acceptance Criteria Progress**
- [x] Warning logged at 80% timeout
- [x] Includes time remaining
- [x] Tasks complete successfully
- [x] Tests verify timeout warnings