### PR TITLE
feat: Add request ID tracking to all HTTP logs

### DIFF
--- a/django-backend/soroscan/log_context.py
+++ b/django-backend/soroscan/log_context.py
@@ -33,9 +33,14 @@ class LogContextFilter(logging.Filter):
     """Add request_id and task_id from context to each LogRecord."""
 
     def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "request_id"):
+            record.request_id = ""
+        if not hasattr(record, "task_id"):
+            record.task_id = ""
+            
         ctx = log_context_var.get()
         if ctx:
             for key, value in ctx.items():
-                if value is not None and not hasattr(record, key):
+                if value is not None:
                     setattr(record, key, value)
         return True

--- a/django-backend/soroscan/middleware.py
+++ b/django-backend/soroscan/middleware.py
@@ -1,6 +1,7 @@
 """
 Middleware for request-scoped log context (request_id) and slow query logging.
 """
+import json
 import logging
 import time
 import uuid
@@ -20,10 +21,30 @@ class RequestIdMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        request_id = getattr(request, "request_id", None) or uuid.uuid4().hex
+        request_id = request.META.get("HTTP_X_REQUEST_ID")
+        if not request_id:
+            request_id = getattr(request, "request_id", None) or str(uuid.uuid4())
+            
         request.request_id = request_id
         set_request_id(request_id)
-        return self.get_response(request)
+        
+        response = self.get_response(request)
+        response["X-Request-ID"] = request_id
+        
+        if response.status_code >= 400 and response.get("Content-Type", "").startswith("application/json"):
+            if not getattr(response, "streaming", False):
+                try:
+                    data = json.loads(response.content)
+                    if isinstance(data, dict):
+                        data["request_id"] = request_id
+                        new_content = json.dumps(data).encode("utf-8")
+                        response.content = new_content
+                        if "Content-Length" in response:
+                            response["Content-Length"] = str(len(new_content))
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+                    
+        return response
 
 
 class ReverseProxyFixedIPMiddleware:

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -303,11 +303,11 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "default": {
-            "format": "%(asctime)s %(name)s %(levelname)s %(message)s",
+            "format": "%(asctime)s %(name)s %(levelname)s [req:%(request_id)s] %(message)s",
         },
         "json": {
             "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
-            "format": "%(asctime)s %(name)s %(levelname)s %(message)s",
+            "format": "%(asctime)s %(name)s %(levelname)s %(request_id)s %(message)s",
         },
     },
     "handlers": {

--- a/django-backend/soroscan/test_middleware.py
+++ b/django-backend/soroscan/test_middleware.py
@@ -1,0 +1,61 @@
+import json
+import uuid
+import pytest
+from django.test import RequestFactory
+from django.http import HttpResponse, JsonResponse
+from soroscan.middleware import RequestIdMiddleware
+from soroscan.log_context import get_log_extra
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+def test_request_id_middleware_generates_uuid_if_missing(rf):
+    request = rf.get("/")
+    def get_response(req):
+        return HttpResponse("OK")
+    
+    middleware = RequestIdMiddleware(get_response)
+    response = middleware(request)
+    
+    assert hasattr(request, "request_id")
+    assert request.request_id is not None
+    assert response["X-Request-ID"] == request.request_id
+    assert get_log_extra().get("request_id") == request.request_id
+
+def test_request_id_middleware_uses_provided_header(rf):
+    test_id = str(uuid.uuid4())
+    request = rf.get("/", HTTP_X_REQUEST_ID=test_id)
+    def get_response(req):
+        return HttpResponse("OK")
+    
+    middleware = RequestIdMiddleware(get_response)
+    response = middleware(request)
+    
+    assert request.request_id == test_id
+    assert response["X-Request-ID"] == test_id
+    assert get_log_extra().get("request_id") == test_id
+
+def test_request_id_middleware_injects_into_error_response(rf):
+    request = rf.get("/")
+    def get_response(req):
+        return JsonResponse({"error": "Not found"}, status=404)
+        
+    middleware = RequestIdMiddleware(get_response)
+    response = middleware(request)
+    
+    data = json.loads(response.content)
+    assert response.status_code == 404
+    assert "request_id" in data
+    assert data["request_id"] == request.request_id
+    
+def test_request_id_middleware_ignores_non_json_error_responses(rf):
+    request = rf.get("/")
+    def get_response(req):
+        return HttpResponse("Error!", status=500)
+    
+    middleware = RequestIdMiddleware(get_response)
+    response = middleware(request)
+    
+    assert response.content == b"Error!"
+    assert response["X-Request-ID"] == request.request_id


### PR DESCRIPTION

Closes #314 

## Description
This PR implements request ID tracking across the complete HTTP stack to enable easier log tracing and improved debugging capabilities.

## Changes Made
- **Middleware Enhancement**: Updated `RequestIdMiddleware` to check for incoming `X-Request-ID` headers. If missing, it dynamically generates a standard UUIDv4 and attaches it to both the request and response headers (`X-Request-ID`).
- **Error Response Injection**: Modified the middleware to intercept non-2xx responses (`status_code >= 400`) and automatically inject the `request_id` into the JSON body payload. This ensures external clients can easily share the specific ID when reporting failures.
- **Log Context Propagation**: Updated `LogContextFilter` and the logging formatters in `settings.py` to automatically include the `request_id` context variable in all log entries emitted during the request lifecycle. Both standard console and JSON formatters have been updated.
- **Tests**: Added comprehensive unit tests in `test_middleware.py` utilizing `pytest` to verify UUID generation, header persistence, and proper error response mutation.

## Verification
- [x] Every HTTP request has a unique UUID assigned and preserved throughout the lifecycle.
- [x] All application logs include the `request_id` field appropriately.
- [x] Error payloads effectively expose the `request_id` to clients.
- [x] Added unit tests pass predictably.