### PR TITLE
feat: API security and deprecation infrastructure #336 #338

### DIFF
--- a/django-backend/.gitignore
+++ b/django-backend/.gitignore
@@ -100,6 +100,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.venv-ci/
 
 # Spyder project settings
 .spyderproject

--- a/django-backend/soroscan/ingest/tests/test_api_security.py
+++ b/django-backend/soroscan/ingest/tests/test_api_security.py
@@ -12,13 +12,10 @@ class ApiSecurityTests(TestCase):
 
     @override_settings(MAX_REQUEST_BODY_SIZE=100)
     def test_request_size_limit(self):
-        """Verify that requests exceeding the limit return 413."""
-        # Create a valid JSON string that exceeds 100 bytes
-        large_data = json.dumps({"data": "x" * 100}) 
-        url = reverse("record-event")
-        self.client.force_login(self.user)
+        """Verify that requests exceeding 100 bytes return 413."""
+        url = reverse("health-check") # Matches path in ingest/urls.py
+        large_data = json.dumps({"test": "x" * 200})
         
-        # Using application/json avoids the 415 error
         response = self.client.post(
             url, 
             data=large_data, 
@@ -28,11 +25,10 @@ class ApiSecurityTests(TestCase):
 
     @override_settings(DEPRECATED_ENDPOINTS={"/api/ingest/audit-trail/": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
     def test_deprecation_headers(self):
-        """Verify that deprecated endpoints include correct headers."""
         self.client.force_login(self.user)
-        # Use the exact string as defined in override_settings to ensure matching
-        path = "/api/ingest/audit-trail/"
-        response = self.client.get(path)
+        url = reverse("audit-trail")
+        response = self.client.get(url)
         
-        self.assertEqual(response.get("Deprecation"), "true")
-        self.assertEqual(response.get("Sunset"), "2026-12-31")
+        # Use .headers for Django 3.2+ / 4.x compatibility in CI
+        self.assertEqual(response.headers.get("Deprecation"), "true")
+        self.assertEqual(response.headers.get("Sunset"), "2026-12-31")

--- a/django-backend/soroscan/ingest/tests/test_api_security.py
+++ b/django-backend/soroscan/ingest/tests/test_api_security.py
@@ -1,0 +1,37 @@
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+class ApiSecurityTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        # Create a user for authenticated endpoints
+        self.user = User.objects.create_user(username='testuser', password='password')
+
+    @override_settings(MAX_REQUEST_BODY_SIZE=100)
+    def test_request_size_limit(self):
+        """Verify that requests exceeding the limit return 413."""
+        large_data = "x" * 150
+        # health-check is public, making it ideal for size testing
+        url = reverse("health-check")
+        response = self.client.post(
+            url, 
+            data=large_data, 
+            content_type="text/plain"
+        )
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.json()["error"], "Payload Too Large")
+
+    @override_settings(DEPRECATED_ENDPOINTS={"/api/ingest/audit-trail/": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
+    def test_deprecation_headers(self):
+        """Verify that deprecated endpoints include correct headers."""
+        self.client.force_login(self.user)
+        # Note: The full path includes the 'api/ingest/' prefix from the main urls.py
+        url = reverse("audit-trail")
+        response = self.client.get(url)
+        
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertEqual(response["Sunset"], "2026-12-31")
+        self.assertIn('rel="replacement"', response["Link"])

--- a/django-backend/soroscan/ingest/tests/test_api_security.py
+++ b/django-backend/soroscan/ingest/tests/test_api_security.py
@@ -10,18 +10,27 @@ class ApiSecurityTests(TestCase):
         self.client = Client()
         self.user = User.objects.create_user(username='testuser', password='password')
 
-    @override_settings(MAX_REQUEST_BODY_SIZE=100)
+   @override_settings(MAX_REQUEST_BODY_SIZE=100)
     def test_request_size_limit(self):
-        """Verify that requests exceeding 100 bytes return 413."""
-        url = reverse("health-check") # Matches path in ingest/urls.py
-        large_data = json.dumps({"test": "x" * 200})
+        """Verify that requests exceeding the limit return 413."""
+        # Use 'record-event' because it is a POST endpoint
+        url = reverse("record-event")
+        
+        # We make the payload specifically larger than 100 bytes
+        large_data = json.dumps({"contract_id": "x" * 150})
+        
+        # Login to bypass any potential permission checks that might run before middleware
+        self.client.force_login(self.user)
         
         response = self.client.post(
             url, 
             data=large_data, 
             content_type="application/json"
         )
+        
+        # This should now return 413 because our middleware hits it before the view
         self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.json().get("error"), "Payload Too Large")
 
     @override_settings(DEPRECATED_ENDPOINTS={"/api/ingest/audit-trail/": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
     def test_deprecation_headers(self):

--- a/django-backend/soroscan/ingest/tests/test_api_security.py
+++ b/django-backend/soroscan/ingest/tests/test_api_security.py
@@ -7,31 +7,33 @@ User = get_user_model()
 class ApiSecurityTests(TestCase):
     def setUp(self):
         self.client = Client()
-        # Create a user for authenticated endpoints
         self.user = User.objects.create_user(username='testuser', password='password')
 
     @override_settings(MAX_REQUEST_BODY_SIZE=100)
     def test_request_size_limit(self):
         """Verify that requests exceeding the limit return 413."""
         large_data = "x" * 150
-        # health-check is public, making it ideal for size testing
-        url = reverse("health-check")
+        # Use 'record-event' because it explicitly allows POST requests
+        url = reverse("record-event")
+        # We need to authenticate to reach the view logic if CSRF/Auth triggers first
+        self.client.force_login(self.user)
+        
         response = self.client.post(
             url, 
             data=large_data, 
             content_type="text/plain"
         )
         self.assertEqual(response.status_code, 413)
-        self.assertEqual(response.json()["error"], "Payload Too Large")
+        self.assertEqual(response.json().get("error"), "Payload Too Large")
 
     @override_settings(DEPRECATED_ENDPOINTS={"/api/ingest/audit-trail/": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
     def test_deprecation_headers(self):
         """Verify that deprecated endpoints include correct headers."""
         self.client.force_login(self.user)
-        # Note: The full path includes the 'api/ingest/' prefix from the main urls.py
         url = reverse("audit-trail")
         response = self.client.get(url)
         
-        self.assertEqual(response["Deprecation"], "true")
-        self.assertEqual(response["Sunset"], "2026-12-31")
-        self.assertIn('rel="replacement"', response["Link"])
+        # Use .get() and check exact casing used in middleware ('Deprecation')
+        self.assertEqual(response.get("Deprecation"), "true")
+        self.assertEqual(response.get("Sunset"), "2026-12-31")
+        self.assertIn('rel="replacement"', response.get("Link", ""))

--- a/django-backend/soroscan/ingest/tests/test_api_security.py
+++ b/django-backend/soroscan/ingest/tests/test_api_security.py
@@ -10,16 +10,12 @@ class ApiSecurityTests(TestCase):
         self.client = Client()
         self.user = User.objects.create_user(username='testuser', password='password')
 
-   @override_settings(MAX_REQUEST_BODY_SIZE=100)
+    @override_settings(MAX_REQUEST_BODY_SIZE=100)
     def test_request_size_limit(self):
         """Verify that requests exceeding the limit return 413."""
-        # Use 'record-event' because it is a POST endpoint
         url = reverse("record-event")
-        
-        # We make the payload specifically larger than 100 bytes
         large_data = json.dumps({"contract_id": "x" * 150})
         
-        # Login to bypass any potential permission checks that might run before middleware
         self.client.force_login(self.user)
         
         response = self.client.post(
@@ -27,17 +23,16 @@ class ApiSecurityTests(TestCase):
             data=large_data, 
             content_type="application/json"
         )
-        
-        # This should now return 413 because our middleware hits it before the view
         self.assertEqual(response.status_code, 413)
         self.assertEqual(response.json().get("error"), "Payload Too Large")
 
-    @override_settings(DEPRECATED_ENDPOINTS={"/api/ingest/audit-trail/": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
+    @override_settings(DEPRECATED_ENDPOINTS={"api/ingest/audit-trail": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
     def test_deprecation_headers(self):
+        """Verify that deprecated endpoints include correct headers."""
         self.client.force_login(self.user)
         url = reverse("audit-trail")
         response = self.client.get(url)
         
-        # Use .headers for Django 3.2+ / 4.x compatibility in CI
         self.assertEqual(response.headers.get("Deprecation"), "true")
         self.assertEqual(response.headers.get("Sunset"), "2026-12-31")
+        self.assertIn('rel="replacement"', response.headers.get("Link", ""))

--- a/django-backend/soroscan/ingest/tests/test_api_security.py
+++ b/django-backend/soroscan/ingest/tests/test_api_security.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+import json
 
 User = get_user_model()
 
@@ -12,28 +13,26 @@ class ApiSecurityTests(TestCase):
     @override_settings(MAX_REQUEST_BODY_SIZE=100)
     def test_request_size_limit(self):
         """Verify that requests exceeding the limit return 413."""
-        large_data = "x" * 150
-        # Use 'record-event' because it explicitly allows POST requests
+        # Create a valid JSON string that exceeds 100 bytes
+        large_data = json.dumps({"data": "x" * 100}) 
         url = reverse("record-event")
-        # We need to authenticate to reach the view logic if CSRF/Auth triggers first
         self.client.force_login(self.user)
         
+        # Using application/json avoids the 415 error
         response = self.client.post(
             url, 
             data=large_data, 
-            content_type="text/plain"
+            content_type="application/json"
         )
         self.assertEqual(response.status_code, 413)
-        self.assertEqual(response.json().get("error"), "Payload Too Large")
 
     @override_settings(DEPRECATED_ENDPOINTS={"/api/ingest/audit-trail/": {"sunset": "2026-12-31", "replacement": "/graphql/"}})
     def test_deprecation_headers(self):
         """Verify that deprecated endpoints include correct headers."""
         self.client.force_login(self.user)
-        url = reverse("audit-trail")
-        response = self.client.get(url)
+        # Use the exact string as defined in override_settings to ensure matching
+        path = "/api/ingest/audit-trail/"
+        response = self.client.get(path)
         
-        # Use .get() and check exact casing used in middleware ('Deprecation')
         self.assertEqual(response.get("Deprecation"), "true")
         self.assertEqual(response.get("Sunset"), "2026-12-31")
-        self.assertIn('rel="replacement"', response.get("Link", ""))

--- a/django-backend/soroscan/middleware.py
+++ b/django-backend/soroscan/middleware.py
@@ -7,9 +7,11 @@ import uuid
 
 from django.conf import settings
 from django.db import connection
+from django.http import JsonResponse
 
 from .log_context import set_request_id
 
+logger = logging.getLogger(__name__)
 slow_query_logger = logging.getLogger("soroscan.slow_queries")
 
 
@@ -90,4 +92,56 @@ class SlowQueryMiddleware:
             for name, value in headers.items():
                 response[name] = value
 
+        return response
+
+class RequestBodySizeMiddleware:
+    """
+    Prevent accidental large requests by rejecting bodies > settings.MAX_REQUEST_BODY_SIZE.
+    Returns 413 Payload Too Large and logs the event.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.max_size = getattr(settings, "MAX_REQUEST_BODY_SIZE", 10485760)
+
+    def __call__(self, request):
+        content_length = request.META.get('CONTENT_LENGTH')
+        
+        if content_length:
+            try:
+                if int(content_length) > self.max_size:
+                    logger.warning(
+                        "Payload Too Large: %s bytes from %s to %s",
+                        content_length,
+                        request.META.get('REMOTE_ADDR'),
+                        request.path
+                    )
+                    return JsonResponse(
+                        {"error": "Payload Too Large", "limit": self.max_size},
+                        status=413
+                    )
+            except (ValueError, TypeError):
+                pass
+
+        return self.get_response(request)
+
+class ApiDeprecationMiddleware:
+    """
+    Injects Deprecation, Sunset, and Link headers for legacy endpoints defined in settings.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.deprecated_paths = getattr(settings, "DEPRECATED_ENDPOINTS", {})
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        
+        # Check if the current path (or path with trailing slash) is deprecated
+        path = request.path
+        config = self.deprecated_paths.get(path) or self.deprecated_paths.get(path + "/")
+        
+        if config:
+            response["Deprecation"] = "true"
+            response["Sunset"] = config["sunset"]
+            response["Link"] = f'<{config["replacement"]}>; rel="replacement"'
+            
         return response

--- a/django-backend/soroscan/middleware.py
+++ b/django-backend/soroscan/middleware.py
@@ -95,53 +95,42 @@ class SlowQueryMiddleware:
         return response
 
 class RequestBodySizeMiddleware:
-    """
-    Prevent accidental large requests by rejecting bodies > settings.MAX_REQUEST_BODY_SIZE.
-    Returns 413 Payload Too Large and logs the event.
-    """
     def __init__(self, get_response):
         self.get_response = get_response
-        self.max_size = getattr(settings, "MAX_REQUEST_BODY_SIZE", 10485760)
 
     def __call__(self, request):
+        # Move size check to the VERY beginning
+        max_size = getattr(settings, "MAX_REQUEST_BODY_SIZE", 10485760)
         content_length = request.META.get('CONTENT_LENGTH')
         
         if content_length:
             try:
-                if int(content_length) > self.max_size:
-                    logger.warning(
-                        "Payload Too Large: %s bytes from %s to %s",
-                        content_length,
-                        request.META.get('REMOTE_ADDR'),
-                        request.path
-                    )
+                if int(content_length) > max_size:
+                    logger.warning("Payload Too Large: %s bytes", content_length)
                     return JsonResponse(
-                        {"error": "Payload Too Large", "limit": self.max_size},
+                        {"error": "Payload Too Large", "limit": max_size},
                         status=413
                     )
             except (ValueError, TypeError):
                 pass
-
         return self.get_response(request)
 
 class ApiDeprecationMiddleware:
-    """
-    Injects Deprecation, Sunset, and Link headers for legacy endpoints defined in settings.
-    """
     def __init__(self, get_response):
         self.get_response = get_response
-        self.deprecated_paths = getattr(settings, "DEPRECATED_ENDPOINTS", {})
 
     def __call__(self, request):
         response = self.get_response(request)
+        deprecated_paths = getattr(settings, "DEPRECATED_ENDPOINTS", {})
         
-        # Check if the current path (or path with trailing slash) is deprecated
-        path = request.path
-        config = self.deprecated_paths.get(path) or self.deprecated_paths.get(path + "/")
+        # Normalize paths by removing leading/trailing slashes for comparison
+        request_path = request.path.strip("/")
         
-        if config:
-            response["Deprecation"] = "true"
-            response["Sunset"] = config["sunset"]
-            response["Link"] = f'<{config["replacement"]}>; rel="replacement"'
-            
+        for path, config in deprecated_paths.items():
+            if path.strip("/") == request_path:
+                response["Deprecation"] = "true"
+                response["Sunset"] = config["sunset"]
+                response["Link"] = f'<{config["replacement"]}>; rel="replacement"'
+                break
+                
         return response

--- a/django-backend/soroscan/middleware.py
+++ b/django-backend/soroscan/middleware.py
@@ -121,16 +121,16 @@ class ApiDeprecationMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
-        deprecated_paths = getattr(settings, "DEPRECATED_ENDPOINTS", {})
+        deprecated_endpoints = getattr(settings, "DEPRECATED_ENDPOINTS", {})
         
-        # Normalize paths by removing leading/trailing slashes for comparison
-        request_path = request.path.strip("/")
+        # Normalize request path: remove leading/trailing slashes
+        norm_request_path = request.path.strip("/")
         
-        for path, config in deprecated_paths.items():
-            if path.strip("/") == request_path:
+        for path, config in deprecated_endpoints.items():
+            # Normalize config path
+            if path.strip("/") == norm_request_path:
                 response["Deprecation"] = "true"
-                response["Sunset"] = config["sunset"]
-                response["Link"] = f'<{config["replacement"]}>; rel="replacement"'
+                response["Sunset"] = config.get("sunset", "")
+                response["Link"] = f'<{config.get("replacement", "")}>; rel="replacement"'
                 break
-                
         return response

--- a/django-backend/soroscan/middleware.py
+++ b/django-backend/soroscan/middleware.py
@@ -99,13 +99,12 @@ class RequestBodySizeMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        # Move size check to the VERY beginning
-        max_size = getattr(settings, "MAX_REQUEST_BODY_SIZE", 10485760)
-        content_length = request.META.get('CONTENT_LENGTH')
-        
-        if content_length:
+        # We check this at the very beginning of the __call__
+        if request.method == "POST":
+            max_size = getattr(settings, "MAX_REQUEST_BODY_SIZE", 10485760)
             try:
-                if int(content_length) > max_size:
+                content_length = int(request.META.get('CONTENT_LENGTH', 0))
+                if content_length > max_size:
                     logger.warning("Payload Too Large: %s bytes", content_length)
                     return JsonResponse(
                         {"error": "Payload Too Large", "limit": max_size},
@@ -113,8 +112,9 @@ class RequestBodySizeMiddleware:
                     )
             except (ValueError, TypeError):
                 pass
+        
         return self.get_response(request)
-
+        
 class ApiDeprecationMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -70,12 +70,14 @@ ENABLE_SILK = env.bool("ENABLE_SILK", default=False)
 MIDDLEWARE = [
     # PrometheusBeforeMiddleware must be first to capture all requests.
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "soroscan.middleware.RequestBodySizeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "soroscan.middleware.ReverseProxyFixedIPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "soroscan.middleware.RequestIdMiddleware",
     "soroscan.middleware.SlowQueryMiddleware",
+    "soroscan.middleware.ApiDeprecationMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -404,3 +406,15 @@ if SENTRY_DSN:
         send_default_pii=False,
         environment=env("SENTRY_ENVIRONMENT", default="production"),
     )
+
+# --- Request Size Limit (Issue #338) ---
+# Default to 10MB (10 * 1024 * 1024 bytes)
+MAX_REQUEST_BODY_SIZE = env.int("MAX_REQUEST_BODY_SIZE", default=10485760)
+
+# --- API Deprecation (Issue #336) ---
+DEPRECATED_ENDPOINTS = {
+    "/api/audit-trail/": {
+        "sunset": "2026-12-31",
+        "replacement": "/graphql/"
+    }
+}

--- a/django-backend/soroscan/settings_test.py
+++ b/django-backend/soroscan/settings_test.py
@@ -44,6 +44,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "soroscan.middleware.ApiDeprecationMiddleware",  
     "django_prometheus.middleware.PrometheusAfterMiddleware",   # must be last
 ]
 
@@ -175,3 +176,6 @@ LOGGING = {
         "level": "WARNING",
     },
 }
+
+MAX_REQUEST_BODY_SIZE = 10485760
+DEPRECATED_ENDPOINTS = {}

--- a/django-backend/soroscan/settings_test.py
+++ b/django-backend/soroscan/settings_test.py
@@ -34,7 +34,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "django_prometheus.middleware.PrometheusBeforeMiddleware",  # must be first
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "soroscan.middleware.RequestBodySizeMiddleware", 
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -44,8 +45,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "soroscan.middleware.ApiDeprecationMiddleware",  
-    "django_prometheus.middleware.PrometheusAfterMiddleware",   # must be last
+    "soroscan.middleware.ApiDeprecationMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "soroscan.urls"  # use main urls.py which has the /metrics route


### PR DESCRIPTION
## Description
This PR addresses two backend infrastructure issues to improve API lifecycle management and security.

## Changes
### 1. API Deprecation Headers (#336)
- Implemented `ApiDeprecationMiddleware` to inject standard headers into legacy endpoints.
- Configurable via `DEPRECATED_ENDPOINTS` in settings.
- Headers included: `Deprecation`, `Sunset`, and `Link` (rel="replacement").

### 2. HTTP Request Body Size Limit (#338)
- Implemented `RequestBodySizeMiddleware` to reject requests exceeding a configurable threshold.
- Defaults to 10MB.
- Returns a `413 Payload Too Large` status code and logs oversized requests for monitoring.

## Validation
- Added `soroscan/ingest/tests/test_api_security.py` covering:
  - Rejection of payloads over the limit.
  - Presence of deprecation/sunset headers on flagged routes.
Closes #336 , Closes #338 