### PR TITLE
feat: add Badge component (#306)

### DIFF
--- a/admin/app/components/Badge.tsx
+++ b/admin/app/components/Badge.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+
+export interface BadgeProps {
+  /** Text content of the badge */
+  label: string;
+  /** Color variant */
+  variant?: 'success' | 'error' | 'warning' | 'info';
+  /** Size variant */
+  size?: 'compact' | 'normal';
+  /** Shape option */
+  shape?: 'rounded' | 'square';
+  /** Optional icon rendered before the label */
+  icon?: React.ReactNode;
+  /** Whether the badge can be dismissed */
+  dismissible?: boolean;
+  /** Callback when dismissed */
+  onDismiss?: () => void;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const variantClasses: Record<NonNullable<BadgeProps['variant']>, string> = {
+  success: 'bg-green-100 text-green-800 border border-green-200',
+  error:   'bg-red-100 text-red-800 border border-red-200',
+  warning: 'bg-yellow-100 text-yellow-800 border border-yellow-200',
+  info:    'bg-blue-100 text-blue-800 border border-blue-200',
+};
+
+const dismissHoverClasses: Record<NonNullable<BadgeProps['variant']>, string> = {
+  success: 'hover:bg-green-200',
+  error:   'hover:bg-red-200',
+  warning: 'hover:bg-yellow-200',
+  info:    'hover:bg-blue-200',
+};
+
+const sizeClasses: Record<NonNullable<BadgeProps['size']>, string> = {
+  compact: 'px-1.5 py-0.5 text-xs gap-1',
+  normal:  'px-2.5 py-1 text-sm gap-1.5',
+};
+
+const shapeClasses: Record<NonNullable<BadgeProps['shape']>, string> = {
+  rounded: 'rounded-full',
+  square:  'rounded',
+};
+
+const Badge: React.FC<BadgeProps> = ({
+  label,
+  variant = 'info',
+  size = 'normal',
+  shape = 'rounded',
+  icon,
+  dismissible = false,
+  onDismiss,
+  className = '',
+}) => {
+  return (
+    <span
+      className={`
+        inline-flex items-center font-medium
+        ${variantClasses[variant]}
+        ${sizeClasses[size]}
+        ${shapeClasses[shape]}
+        ${className}
+      `.trim().replace(/\s+/g, ' ')}
+      role="status"
+      aria-label={label}
+    >
+      {icon && (
+        <span className="inline-flex shrink-0" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+
+      <span>{label}</span>
+
+      {dismissible && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label={`Dismiss ${label}`}
+          className={`
+            inline-flex items-center justify-center shrink-0 rounded-full
+            -mr-0.5 ml-0.5 w-4 h-4
+            transition-colors
+            ${dismissHoverClasses[variant]}
+          `.trim().replace(/\s+/g, ' ')}
+        >
+          <svg
+            viewBox="0 0 8 8"
+            fill="currentColor"
+            className="w-2.5 h-2.5"
+            aria-hidden="true"
+          >
+            <path d="M1.5 1.5l5 5M6.5 1.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+};
+
+export default Badge;

--- a/admin/app/components/__tests__/Badge.test.tsx
+++ b/admin/app/components/__tests__/Badge.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Badge from '../Badge';
+
+describe('Badge', () => {
+  // --- Rendering ---
+  it('renders with required label', () => {
+    render(<Badge label="Active" />);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('has role="status"', () => {
+    render(<Badge label="Active" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  // --- Variant colours ---
+  it('applies success variant classes', () => {
+    const { container } = render(<Badge label="OK" variant="success" />);
+    expect(container.firstChild).toHaveClass('bg-green-100', 'text-green-800');
+  });
+
+  it('applies error variant classes', () => {
+    const { container } = render(<Badge label="Fail" variant="error" />);
+    expect(container.firstChild).toHaveClass('bg-red-100', 'text-red-800');
+  });
+
+  it('applies warning variant classes', () => {
+    const { container } = render(<Badge label="Warn" variant="warning" />);
+    expect(container.firstChild).toHaveClass('bg-yellow-100', 'text-yellow-800');
+  });
+
+  it('applies info variant classes (default)', () => {
+    const { container } = render(<Badge label="Info" />);
+    expect(container.firstChild).toHaveClass('bg-blue-100', 'text-blue-800');
+  });
+
+  // --- Size variants ---
+  it('applies normal size classes by default', () => {
+    const { container } = render(<Badge label="Normal" />);
+    expect(container.firstChild).toHaveClass('px-2.5', 'py-1', 'text-sm');
+  });
+
+  it('applies compact size classes', () => {
+    const { container } = render(<Badge label="Small" size="compact" />);
+    expect(container.firstChild).toHaveClass('px-1.5', 'py-0.5', 'text-xs');
+  });
+
+  // --- Shape variants ---
+  it('applies rounded shape by default', () => {
+    const { container } = render(<Badge label="Pill" />);
+    expect(container.firstChild).toHaveClass('rounded-full');
+  });
+
+  it('applies square shape', () => {
+    const { container } = render(<Badge label="Square" shape="square" />);
+    expect(container.firstChild).toHaveClass('rounded');
+    expect(container.firstChild).not.toHaveClass('rounded-full');
+  });
+
+  // --- Icon support ---
+  it('renders icon when provided', () => {
+    render(<Badge label="With Icon" icon={<svg data-testid="test-icon" />} />);
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('renders without icon when not provided', () => {
+    render(<Badge label="No Icon" />);
+    expect(screen.queryByTestId('test-icon')).not.toBeInTheDocument();
+  });
+
+  // --- Dismissible ---
+  it('renders dismiss button when dismissible=true', () => {
+    render(<Badge label="Close me" dismissible />);
+    expect(screen.getByRole('button', { name: /dismiss close me/i })).toBeInTheDocument();
+  });
+
+  it('does not render dismiss button by default', () => {
+    render(<Badge label="Static" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const handleDismiss = jest.fn();
+    render(<Badge label="Bye" dismissible onDismiss={handleDismiss} />);
+    fireEvent.click(screen.getByRole('button', { name: /dismiss bye/i }));
+    expect(handleDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismiss button is accessible with aria-label', () => {
+    render(<Badge label="Tag" dismissible />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-label', 'Dismiss Tag');
+  });
+
+  // --- Custom className ---
+  it('applies custom className', () => {
+    const { container } = render(<Badge label="Custom" className="my-custom-class" />);
+    expect(container.firstChild).toHaveClass('my-custom-class');
+  });
+});

--- a/admin/app/components/index.ts
+++ b/admin/app/components/index.ts
@@ -10,5 +10,5 @@ export type { SearchHistoryProps, SearchHistoryItem } from './SearchHistory';
 export { default as ProgressBar } from './ProgressBar';
 export type { ProgressBarProps } from './ProgressBar';
 
-export { default as ProgressBar } from './ProgressBar';
-export type { ProgressBarProps } from './ProgressBar';
+export { default as Badge } from './Badge';
+export type { BadgeProps } from './Badge';


### PR DESCRIPTION
- Add Badge component with success/error/warning/info variants
- Support compact and normal size variants
- Support rounded (pill) and square shape options
- Optional icon slot rendered before label
- Dismissible option with onDismiss callback and accessible aria-label
- Export Badge from components index (also fix duplicate ProgressBar export)
- Add 17 tests covering all variants, sizes, shapes, icon, dismiss, and className

closes #306 