### PR TITLE
feat - Add configurable CORS origins via ALLOWED_ORIGINS environment variable

### DIFF
--- a/django-backend/.env.example
+++ b/django-backend/.env.example
@@ -42,7 +42,7 @@ INDEXER_SECRET_KEY=SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Comma-separated list of allowed origins (leave empty to use CORS_ALLOW_ALL_ORIGINS when DEBUG=True)
 # Example: http://localhost:3000,http://localhost:5173
 # For production, specify your frontend domain(s)
-CORS_ALLOWED_ORIGINS=http://localhost:3000
+ALLOWED_ORIGINS=http://localhost:3000
 
 # Logging Configuration
 # Set to "json" for structured JSON logs (recommended for production)

--- a/django-backend/soroscan/ingest/tests/test_cors_config.py
+++ b/django-backend/soroscan/ingest/tests/test_cors_config.py
@@ -1,4 +1,3 @@
-import pytest
 from soroscan import settings as app_settings
 
 

--- a/django-backend/soroscan/ingest/tests/test_cors_config.py
+++ b/django-backend/soroscan/ingest/tests/test_cors_config.py
@@ -1,0 +1,64 @@
+import pytest
+from soroscan import settings as app_settings
+
+
+class TestAllowedOriginsConfiguration:
+    def test_single_origin_parsing(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:3000")
+
+        import importlib
+        importlib.reload(app_settings)
+
+        assert app_settings.CORS_ALLOWED_ORIGINS == ["http://localhost:3000"]
+
+    def test_multiple_origins_parsing(self, monkeypatch):
+        monkeypatch.setenv(
+            "ALLOWED_ORIGINS",
+            "http://localhost:3000,http://localhost:5173,https://app.example.com",
+        )
+
+        import importlib
+        importlib.reload(app_settings)
+
+        assert app_settings.CORS_ALLOWED_ORIGINS == [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "https://app.example.com",
+        ]
+
+    def test_empty_origins_returns_empty_list(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_ORIGINS", "")
+
+        import importlib
+        importlib.reload(app_settings)
+
+        assert app_settings.CORS_ALLOWED_ORIGINS == []
+
+    def test_production_url_parsing(self, monkeypatch):
+        monkeypatch.setenv(
+            "ALLOWED_ORIGINS",
+            "https://soroscan.example.com,https://www.soroscan.example.com",
+        )
+
+        import importlib
+        importlib.reload(app_settings)
+
+        assert app_settings.CORS_ALLOWED_ORIGINS == [
+            "https://soroscan.example.com",
+            "https://www.soroscan.example.com",
+        ]
+
+    def test_whitespace_handling(self, monkeypatch):
+        monkeypatch.setenv(
+            "ALLOWED_ORIGINS",
+            "http://localhost:3000 , https://app.example.com , http://localhost:5173",
+        )
+
+        import importlib
+        importlib.reload(app_settings)
+
+        assert app_settings.CORS_ALLOWED_ORIGINS == [
+            "http://localhost:3000",
+            "https://app.example.com",
+            "http://localhost:5173",
+        ]

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -205,8 +205,9 @@ SIMPLE_JWT = {
 }
 
 # CORS
+origins_str = env("ALLOWED_ORIGINS", default="")
+CORS_ALLOWED_ORIGINS = [o.strip() for o in origins_str.split(",") if o.strip()] if origins_str else []
 CORS_ALLOW_ALL_ORIGINS = DEBUG
-CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[])
 CORS_ALLOW_CREDENTIALS = True  # Required for Apollo Client with credentials: 'include'
 
 # Channels

--- a/django-backend/soroscan/settings_test.py
+++ b/django-backend/soroscan/settings_test.py
@@ -130,6 +130,7 @@ REST_FRAMEWORK = {
 
 # CORS
 CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = []
 
 # Celery - Test settings (synchronous execution)
 CELERY_TASK_ALWAYS_EAGER = True


### PR DESCRIPTION
Summary

Make CORS origins configurable via environment variable.

Changes
- Settings (soroscan/settings.py): Read CORS origins from ALLOWED_ORIGINS env var instead of hardcoded value. Uses comma-separated parsing with whitespace trimming for robustness.
- Environment files (.env, .env.example): Updated variable from CORS_ALLOWED_ORIGINS to ALLOWED_ORIGINS.
- Test settings (soroscan/settings_test.py): Added explicit CORS_ALLOWED_ORIGINS configuration.
- Tests (new test_cors_config.py): Added 5 tests verifying configuration parsing.

How to test
cd django-backend
ALLOWED_ORIGINS="http://localhost:3000,https://app.example.com" python manage.py check
Or configure multiple origins:
ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
Acceptance Criteria
- [x] CORS origins read from env var
- [x] Supports multiple origins (comma-separated)
- [x] Works with localhost and production
- [x] Tests verify configuration

closes #322 