### PR TITLE
feat: add export_contracts command and Clear Cache admin action (#421…

### DIFF
--- a/django-backend/soroscan/ingest/admin.py
+++ b/django-backend/soroscan/ingest/admin.py
@@ -192,7 +192,7 @@ class TrackedContractAdmin(AdminAuditMixin, admin.ModelAdmin):
     readonly_fields = ["created_at", "updated_at"]
     ordering = ["-created_at", "name"]
     action_form = BackfillActionForm
-    actions = ["backfill_events"]
+    actions = ["backfill_events", "clear_cache"]
     fieldsets = (
         (None, {
             "fields": (
@@ -282,6 +282,22 @@ class TrackedContractAdmin(AdminAuditMixin, admin.ModelAdmin):
                 f"Backfill started for {len(task_ids)} contract(s). Task IDs: {task_ids_text}",
                 level=messages.SUCCESS,
             )
+
+    @admin.action(description="Clear Redis cache for selected contracts")
+    def clear_cache(self, request, queryset):
+        from .cache_utils import invalidate_contract_query_cache, invalidate_event_count_cache
+
+        cleared = 0
+        for contract in queryset:
+            invalidate_contract_query_cache(contract.contract_id)
+            invalidate_event_count_cache(contract.contract_id)
+            cleared += 1
+
+        self.message_user(
+            request,
+            f"Cache cleared for {cleared} contract(s).",
+            level=messages.SUCCESS,
+        )
 
 
 @admin.register(EventSchema)

--- a/django-backend/soroscan/ingest/management/commands/export_contracts.py
+++ b/django-backend/soroscan/ingest/management/commands/export_contracts.py
@@ -1,0 +1,54 @@
+"""
+Management command: export_contracts
+
+Exports all TrackedContract records (address and name) to a JSON file.
+
+Usage:
+    python manage.py export_contracts --output contracts.json
+    python manage.py export_contracts --output contracts.json --pretty
+"""
+import json
+import sys
+
+from django.core.management.base import BaseCommand
+
+from soroscan.ingest.models import TrackedContract
+
+
+class Command(BaseCommand):
+    help = "Export all indexed contracts (address and name) to a JSON file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            required=True,
+            help="Output file path (use - for stdout)",
+        )
+        parser.add_argument(
+            "--pretty",
+            action="store_true",
+            default=False,
+            help="Pretty-print the JSON output",
+        )
+
+    def handle(self, *args, **options):
+        output = options["output"]
+        pretty = options["pretty"]
+        indent = 2 if pretty else None
+
+        contracts = list(
+            TrackedContract.objects.values("contract_id", "name").order_by("contract_id")
+        )
+
+        data = {"contracts": contracts}
+
+        if output == "-":
+            json.dump(data, sys.stdout, indent=indent)
+            sys.stdout.write("\n")
+        else:
+            with open(output, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=indent)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Exported {len(contracts)} contract(s) to {output}")
+        )


### PR DESCRIPTION
…, #422)

## Issue #421 — Add management command to export all indexed contracts to JSON

### What was done
Added a new Django management command at:
  soroscan/ingest/management/commands/export_contracts.py

### How it was implemented
- The command queries TrackedContract.objects.values('contract_id', 'name') ordered by contract_id, which is the minimal set of fields required by the acceptance criteria (address + name).
- Output is wrapped in a top-level {'contracts': [...]} envelope for forward compatibility.
- --output accepts a file path or '-' for stdout, consistent with the existing export_events command style in this codebase.
- --pretty flag controls indentation (indent=2 when set, compact otherwise), satisfying the 'pretty printing works correctly' acceptance criterion.
- No external dependencies are introduced; only stdlib json and Django ORM.

### Acceptance criteria met
  ✅ Command exports valid JSON ✅ All required fields are present (contract_id, name) ✅ Pretty printing works correctly (--pretty flag)

---

## Issue #422 — Add 'Clear Cache' admin action for contracts in Django Admin

### What was done
Added a 'Clear Redis cache for selected contracts' bulk action to TrackedContractAdmin in:
  soroscan/ingest/admin.py

### How it was implemented
- Registered 'clear_cache' in the TrackedContractAdmin.actions list alongside the existing 'backfill_events' action.
- The action iterates over the selected queryset and calls two existing cache_utils helpers for each contract: • invalidate_contract_query_cache(contract_id) — deletes the contract_stats Redis key computed via stable_cache_key. • invalidate_event_count_cache(contract_id) — deletes the event_count:<id> Redis key.
- Both helpers are imported lazily inside the action to avoid circular imports.
- After processing, a Django messages.SUCCESS notification reports the number of contracts whose cache was cleared.

### Acceptance criteria met
  ✅ Admin action is selectable in the list ✅ Redis keys are deleted upon execution ✅ Success message shows number of items cleared

Closes #421 
Closes #422 