### PR TITLE
Implement guaranteed webhook delivery with escalation and acknowledgment

### DIFF
--- a/django-backend/soroscan/ingest/metrics.py
+++ b/django-backend/soroscan/ingest/metrics.py
@@ -23,6 +23,7 @@ __all__ = [
     "webhook_ack_total",
     "webhook_sla_total",
     "webhook_escalations_total",
+    "webhook_deduplicated_total",
     "alert_rules_evaluated_total",
     "alert_deduplicated_total",
     "remediation_rules_evaluated_total",
@@ -164,6 +165,12 @@ webhook_escalations_total = _get_or_create(
     "soroscan_webhook_escalations_total",
     "Number of escalation notifications sent for webhook failures",
     ["channel", "status"],
+)
+
+webhook_deduplicated_total = _get_or_create(
+    Counter,
+    "soroscan_webhook_deduplicated_total",
+    "Number of webhook deliveries skipped due to deduplication",
 )
 
 alert_rules_evaluated_total = _get_or_create(

--- a/django-backend/soroscan/ingest/tasks.py
+++ b/django-backend/soroscan/ingest/tasks.py
@@ -800,6 +800,31 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
         )
         return False
 
+    # Deduplicate identical webhook deliveries to prevent floods
+    dedup_window = int(getattr(settings, "WEBHOOK_DEDUP_WINDOW_SECONDS", 300))
+    dedup_material = json.dumps(
+        {
+            "subscription_id": subscription_id,
+            "contract_id": event.contract.contract_id,
+            "event_type": event.event_type,
+            "ledger": event.ledger,
+            "event_index": event.event_index,
+            "payload": event.payload,
+        },
+        sort_keys=True,
+    )
+    dedup_hash = hashlib.sha256(dedup_material.encode("utf-8")).hexdigest()
+    dedup_key = f"soroscan:webhooks:dedup:{subscription_id}:{dedup_hash}"
+    if not cache.add(dedup_key, "1", timeout=dedup_window):
+        logger.info(
+            "Deduplicated webhook delivery for subscription=%s event=%s",
+            subscription_id,
+            event_id,
+            extra={"webhook_id": subscription_id, "event_id": event_id},
+        )
+        m.webhook_deduplicated_total.inc()
+        return True  # Consider deduplicated delivery as successful
+
     event_data = {
         "contract_id": event.contract.contract_id,
         "event_type": event.event_type,

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -304,6 +304,9 @@ WEBHOOK_ESCALATION_PAGERDUTY_TARGET = env(
     "WEBHOOK_ESCALATION_PAGERDUTY_TARGET", default=""
 )
 
+# Webhook deduplication window
+WEBHOOK_DEDUP_WINDOW_SECONDS = env.int("WEBHOOK_DEDUP_WINDOW_SECONDS", default=300)
+
 # Dependency change alert deduplication
 DOWNSTREAM_ALERT_DEDUP_SECONDS = env.int("DOWNSTREAM_ALERT_DEDUP_SECONDS", default=3600)
 


### PR DESCRIPTION
- Add webhook deduplication to prevent floods of identical alerts
- Require explicit acknowledgment header for successful delivery
- Implement escalation policies (Slack -> SMS -> PagerDuty) on failures
- Store failed deliveries in dead-letter queue for manual review
- Track delivery SLA metrics (% delivered within SLA)
- Add webhook_deduplicated_total metric
- Add WEBHOOK_DEDUP_WINDOW_SECONDS setting

Closes #361