### PR TITLE
chore: configure pre-commit hooks for black, flake8, and isort

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,.venv,venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+exclude: '(?x)^(
+    .*/node_modules/|
+    .*/\.venv.*/|
+    .*/\.git/|
+    .*/\.cache/|
+    .*/dist/|
+    .*/build/
+)'
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+        args: [--allow-multiple-documents]
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.isort]
+profile = "black"
+line_length = 88


### PR DESCRIPTION
**What this PR does**
This PR configures pre-commit hooks for black, flake8, and isort to ensure consistent code formatting and quality across the repository.

**Root cause**
- Pre-commit hooks were not configured in the repository.

**Fix**
- Added .pre-commit-config.yaml with trailing-whitespace, end-of-file-fixer, check-yaml, and check-added-large-files hooks.
- Configured lack, lake8, and isort hooks.
- Added pyproject.toml and .flake8 to configure the tools consistently.
- Configured exclusions for common directories like 
ode_modules and .venv.

**Testing**
- [x] Bug reproduced before fix: N/A (Chore)
- [x] Regression test added/updated: N/A
- [x] Targeted/affected checks pass locally: pre-commit run --all-files
- [x] CI is green

Closes #374