### PR TITLE
Add gzip compression for responses larger than 1KB

### DIFF
--- a/django-backend/soroscan/ingest/tests/test_new_features.py
+++ b/django-backend/soroscan/ingest/tests/test_new_features.py
@@ -372,6 +372,62 @@ class SlowQueryMiddlewareTests(TestCase):
 
 
 # ---------------------------------------------------------------------------
+# ConditionalGZipMiddleware tests
+# ---------------------------------------------------------------------------
+
+class ConditionalGZipMiddlewareTests(TestCase):
+    def test_compresses_large_response(self):
+        from soroscan.middleware import ConditionalGZipMiddleware
+        from django.http import HttpResponse
+        
+        content = "x" * 2000
+        
+        def get_response(req):
+            return HttpResponse(content)
+            
+        mw = ConditionalGZipMiddleware(get_response)
+        request = RequestFactory().get("/", HTTP_ACCEPT_ENCODING="gzip")
+        response = mw(request)
+        
+        self.assertEqual(response.get("Content-Encoding"), "gzip")
+        self.assertNotEqual(response.content, content.encode())
+        self.assertTrue(len(response.content) < len(content))
+
+    def test_does_not_compress_small_response(self):
+        from soroscan.middleware import ConditionalGZipMiddleware
+        from django.http import HttpResponse
+        
+        content = "x" * 500
+        
+        def get_response(req):
+            return HttpResponse(content)
+            
+        mw = ConditionalGZipMiddleware(get_response)
+        request = RequestFactory().get("/", HTTP_ACCEPT_ENCODING="gzip")
+        response = mw(request)
+        
+        self.assertIsNone(response.get("Content-Encoding"))
+        self.assertEqual(response.content, content.encode())
+
+    def test_does_not_compress_if_already_compressed(self):
+        from soroscan.middleware import ConditionalGZipMiddleware
+        from django.http import HttpResponse
+        
+        content = b"fakecompressed" * 200 # Over 1KB
+        
+        def get_response(req):
+            resp = HttpResponse(content)
+            resp["Content-Encoding"] = "gzip"
+            return resp
+            
+        mw = ConditionalGZipMiddleware(get_response)
+        request = RequestFactory().get("/", HTTP_ACCEPT_ENCODING="gzip")
+        response = mw(request)
+        
+        self.assertEqual(response.content, content)
+
+
+# ---------------------------------------------------------------------------
 # APIKeyViewSet tests
 # ---------------------------------------------------------------------------
 

--- a/django-backend/soroscan/middleware.py
+++ b/django-backend/soroscan/middleware.py
@@ -152,3 +152,17 @@ class ApiDeprecationMiddleware:
                 response["Link"] = f'<{config.get("replacement", "")}>; rel="replacement"'
                 break
         return response
+
+
+from django.middleware.gzip import GZipMiddleware
+
+class ConditionalGZipMiddleware(GZipMiddleware):
+    """
+    Compress content if the browser allows gzip compression,
+    but only if the response is larger than 1KB.
+    """
+    def process_response(self, request, response):
+        if not response.streaming and len(response.content) < 1024:
+            return response
+            
+        return super().process_response(request, response)

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -70,6 +70,7 @@ ENABLE_SILK = env.bool("ENABLE_SILK", default=False)
 MIDDLEWARE = [
     # PrometheusBeforeMiddleware must be first to capture all requests.
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "soroscan.middleware.ConditionalGZipMiddleware",
     "soroscan.middleware.RequestBodySizeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
## 📌 Summary
Implements gzip compression for REST and GraphQL responses to reduce network payload size (#320).

## 🚀 What was done
- Created a custom `ConditionalGZipMiddleware` in `django-backend/soroscan/middleware.py`.
- Inherited from Django's built-in `GZipMiddleware` to cleanly leverage standard compression logic while enforcing our specific threshold.
- Placed the middleware strategically within the `MIDDLEWARE` list in `settings.py` so it processes responses late in the request lifecycle.
- Included robust tests to verify the compression applies accurately.

## 🧠 Key Logic
- **Conditional Compression:** Hooked into the response processing to ensure we only compress payloads larger than `1KB`. Small responses bypass the compression step to avoid CPU overhead and the situation where compression increases the payload size.
- **Double Compression Avoidance:** Leverages existing headers to check if the `Content-Encoding` header has already been set.
- **Client Support Validation:** Native Django middleware handles the `Accept-Encoding: gzip` requirement seamlessly.

## 🧪 Tests
- ✅ `test_compresses_large_response`: Verifies responses > 1KB get gzipped and have the correct headers.
- ✅ `test_does_not_compress_small_response`: Ensures responses < 1KB remain uncompressed to avoid performance impact.
- ✅ `test_does_not_compress_if_already_compressed`: Guarantees we do not double-compress an already gzipped response.

Closes #320
