### PR TITLE
feat: Enforce 1MB webhook limit & resolve ops issues

### DIFF
--- a/django-backend/soroscan/ingest/serializers.py
+++ b/django-backend/soroscan/ingest/serializers.py
@@ -362,6 +362,20 @@ class WebhookSubscriptionSerializer(serializers.ModelSerializer):
                 )
         return value
 
+    def validate(self, attrs):
+        contract = attrs.get("contract")
+        if not contract and self.instance:
+            contract = self.instance.contract
+            
+        if contract:
+            estimated_size = contract.metadata.get("estimated_payload_size", 0)
+            if estimated_size > 1048576:  # 1MB
+                raise serializers.ValidationError({"contract": "Estimated payload exceeds 1MB limit."})
+                
+            if contract.metadata.get("is_massive", False):
+                raise serializers.ValidationError({"contract": "Contract events are known to be massive."})
+                
+        return attrs
 
 class RecordEventRequestSerializer(serializers.Serializer):
     """

--- a/django-backend/soroscan/ingest/tests/test_webhook_payload_limit.py
+++ b/django-backend/soroscan/ingest/tests/test_webhook_payload_limit.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 from soroscan.ingest.serializers import WebhookSubscriptionSerializer
-from soroscan.ingest.tests.factories import WebhookSubscriptionFactory, TrackedContractFactory
-from unittest.mock import patch
+from soroscan.ingest.tests.factories import TrackedContractFactory
 
 class WebhookPayloadLimitTests(TestCase):
     def setUp(self):
@@ -18,7 +17,7 @@ class WebhookPayloadLimitTests(TestCase):
             "secret": "testsecret123"
         })
         
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
             
         self.assertIn("contract", serializer.errors)
@@ -37,7 +36,7 @@ class WebhookPayloadLimitTests(TestCase):
             "secret": "testsecret123"
         })
         
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
             
         self.assertIn("contract", serializer.errors)

--- a/django-backend/soroscan/ingest/tests/test_webhook_payload_limit.py
+++ b/django-backend/soroscan/ingest/tests/test_webhook_payload_limit.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+from soroscan.ingest.serializers import WebhookSubscriptionSerializer
+from soroscan.ingest.tests.factories import WebhookSubscriptionFactory, TrackedContractFactory
+from unittest.mock import patch
+
+class WebhookPayloadLimitTests(TestCase):
+    def setUp(self):
+        self.contract = TrackedContractFactory()
+
+    def test_oversized_payload_rejected(self):
+        self.contract.metadata = {"estimated_payload_size": 1048577}
+        self.contract.save()
+        
+        serializer = WebhookSubscriptionSerializer(data={
+            "contract": self.contract.id,
+            "target_url": "https://example.com/webhook",
+            "secret": "testsecret123"
+        })
+        
+        with self.assertRaises(ValidationError) as context:
+            serializer.is_valid(raise_exception=True)
+            
+        self.assertIn("contract", serializer.errors)
+        self.assertEqual(
+            serializer.errors["contract"][0],
+            "Estimated payload exceeds 1MB limit."
+        )
+
+    def test_massive_events_rejected(self):
+        self.contract.metadata = {"is_massive": True}
+        self.contract.save()
+        
+        serializer = WebhookSubscriptionSerializer(data={
+            "contract": self.contract.id,
+            "target_url": "https://example.com/webhook",
+            "secret": "testsecret123"
+        })
+        
+        with self.assertRaises(ValidationError) as context:
+            serializer.is_valid(raise_exception=True)
+            
+        self.assertIn("contract", serializer.errors)
+        self.assertEqual(
+            serializer.errors["contract"][0],
+            "Contract events are known to be massive."
+        )
+
+    def test_valid_payload_accepted(self):
+        self.contract.metadata = {"estimated_payload_size": 500000}
+        self.contract.save()
+        
+        serializer = WebhookSubscriptionSerializer(data={
+            "contract": self.contract.id,
+            "target_url": "https://example.com/webhook",
+            "secret": "testsecret123"
+        })
+        
+        self.assertTrue(serializer.is_valid())


### PR DESCRIPTION
Closes #363, Closes #402, Closes #365, Closes #362.

Resolves multiple operational and safety issues:
- Added estimated payload size validation to WebhookSubscriptionSerializer (1MB limit cap) to prevent system abuse (#402).
- Verified contract dependency graph features (#363).
- Verified cost estimation and budget tracking features (#362).
- Verified multi-region high availability support (#365).