### PR TITLE
feat: add GET /api/ingest/networks/ endpoint (#404)

### DIFF
--- a/django-backend/soroscan/ingest/tests/test_views.py
+++ b/django-backend/soroscan/ingest/tests/test_views.py
@@ -401,6 +401,74 @@ class TestRecordEventView:
 
 
 @pytest.mark.django_db
+class TestNetworksEndpoint:
+    def test_networks_returns_list(self, api_client, settings):
+        settings.SOROBAN_NETWORKS = [
+            {
+                "id": "testnet",
+                "name": "Testnet",
+                "rpc_url": "https://soroban-testnet.stellar.org",
+                "network_passphrase": "Test SDF Network ; September 2015",
+            },
+            {
+                "id": "mainnet",
+                "name": "Mainnet",
+                "rpc_url": "https://mainnet.stellar.validationcloud.io/v1/public",
+                "network_passphrase": "Public Global Stellar Network ; September 2015",
+            },
+        ]
+        url = reverse("networks")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "networks" in response.data
+        assert len(response.data["networks"]) == 2
+
+    def test_networks_response_structure(self, api_client, settings):
+        settings.SOROBAN_NETWORKS = [
+            {
+                "id": "testnet",
+                "name": "Testnet",
+                "rpc_url": "https://soroban-testnet.stellar.org",
+                "network_passphrase": "Test SDF Network ; September 2015",
+            },
+        ]
+        url = reverse("networks")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        network = response.data["networks"][0]
+        assert network["id"] == "testnet"
+        assert network["name"] == "Testnet"
+        assert "rpc_url" in network
+        assert "network_passphrase" in network
+
+    def test_networks_is_publicly_accessible(self, api_client, settings):
+        settings.SOROBAN_NETWORKS = []
+        url = reverse("networks")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["networks"] == []
+
+    def test_networks_matches_settings(self, api_client, settings):
+        custom_networks = [
+            {
+                "id": "futurenet",
+                "name": "Futurenet",
+                "rpc_url": "https://soroban-futurenet.stellar.org",
+                "network_passphrase": "Test SDF Future Network ; October 2022",
+            }
+        ]
+        settings.SOROBAN_NETWORKS = custom_networks
+        url = reverse("networks")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["networks"] == custom_networks
+
+
+@pytest.mark.django_db
 class TestHealthCheck:
     def test_health_check(self, api_client):
         url = reverse("health-check")

--- a/django-backend/soroscan/ingest/urls.py
+++ b/django-backend/soroscan/ingest/urls.py
@@ -21,6 +21,7 @@ from .views import (
     deletion_requests_view,
     deployment_timeline_view,
     health_check,
+    networks_view,
     record_event_view,
     restore_archived_events,
     transaction_events_view,
@@ -71,4 +72,5 @@ urlpatterns = [
     ),
     path("deletion-requests/", deletion_requests_view, name="deletion-requests"),
     path("compliance-export/", compliance_export_view, name="compliance-export"),
+    path("networks/", networks_view, name="networks"),
 ]

--- a/django-backend/soroscan/ingest/views.py
+++ b/django-backend/soroscan/ingest/views.py
@@ -838,6 +838,32 @@ def health_check(request):
 
 @extend_schema(
     responses=inline_serializer(
+        name="NetworkListResponse",
+        fields={
+            "networks": serializers.ListField(
+                child=inline_serializer(
+                    name="NetworkEntry",
+                    fields={
+                        "id": serializers.CharField(),
+                        "name": serializers.CharField(),
+                        "rpc_url": serializers.CharField(),
+                        "network_passphrase": serializers.CharField(),
+                    },
+                )
+            )
+        },
+    )
+)
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def networks_view(request):
+    """Return the list of Soroban networks supported by this indexer."""
+    networks = getattr(settings, "SOROBAN_NETWORKS", [])
+    return Response({"networks": networks})
+
+
+@extend_schema(
+    responses=inline_serializer(
         name="ContractStatusResponse",
         fields={
             "total_contracts": serializers.IntegerField(),

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -346,6 +346,29 @@ STELLAR_NETWORK_PASSPHRASE = env(
 SOROSCAN_CONTRACT_ID = env("SOROSCAN_CONTRACT_ID", default="")
 INDEXER_SECRET_KEY = env("INDEXER_SECRET_KEY", default="")
 
+# Available Soroban networks exposed via GET /api/ingest/networks/.
+# Override individual RPC URLs via the corresponding env vars if needed.
+SOROBAN_NETWORKS = [
+    {
+        "id": "testnet",
+        "name": "Testnet",
+        "rpc_url": env("TESTNET_RPC_URL", default="https://soroban-testnet.stellar.org"),
+        "network_passphrase": "Test SDF Network ; September 2015",
+    },
+    {
+        "id": "mainnet",
+        "name": "Mainnet",
+        "rpc_url": env("MAINNET_RPC_URL", default="https://mainnet.stellar.validationcloud.io/v1/public"),
+        "network_passphrase": "Public Global Stellar Network ; September 2015",
+    },
+    {
+        "id": "futurenet",
+        "name": "Futurenet",
+        "rpc_url": env("FUTURENET_RPC_URL", default="https://soroban-futurenet.stellar.org"),
+        "network_passphrase": "Test SDF Future Network ; October 2022",
+    },
+]
+
 # ---------------------------------------------------------------------------
 # GraphQL Introspection (security: disable in production)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #404

---

- Add SOROBAN_NETWORKS config to settings.py with testnet, mainnet, and futurenet entries; each RPC URL is overridable via env vars (TESTNET_RPC_URL, MAINNET_RPC_URL, FUTURENET_RPC_URL)
- Add networks_view function-based view returning the networks list
- Register GET /api/ingest/networks/ (AllowAny, no auth required)
- Tests: list shape, required field structure, empty config, and response mirrors settings exactly