### PR TITLE
feat: add ping endpoint to verify webhook listener health (#403)

### DIFF
--- a/django-backend/soroscan/ingest/tasks.py
+++ b/django-backend/soroscan/ingest/tasks.py
@@ -1159,6 +1159,57 @@ def dispatch_webhook(self, subscription_id: int, event_id: int) -> bool:
     return False
 
 
+@shared_task(name="ingest.tasks.ping_webhook", bind=True)
+def ping_webhook(self, subscription_id: int) -> dict:
+    """
+    Send a minimal ping payload to a webhook endpoint to verify it is reachable.
+
+    Returns a dict with ``success`` (bool) and either ``status_code`` (int) on
+    a network response or ``error`` (str) on a connection failure.
+    """
+    try:
+        webhook = WebhookSubscription.objects.get(id=subscription_id)
+    except WebhookSubscription.DoesNotExist:
+        logger.warning(
+            "Webhook subscription %s not found for ping",
+            subscription_id,
+            extra={"webhook_id": subscription_id},
+        )
+        return {"success": False, "error": "Subscription not found"}
+
+    payload = {"type": "ping", "timestamp": timezone.now().isoformat()}
+    payload_bytes = json.dumps(payload, sort_keys=True).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "X-SoroScan-Event": "ping",
+    }
+
+    try:
+        response = requests.post(
+            webhook.target_url,
+            data=payload_bytes,
+            headers=headers,
+            timeout=webhook.timeout_seconds,
+        )
+        success = response.status_code == 200
+        logger.info(
+            "Ping webhook %s -> %s (HTTP %d)",
+            subscription_id,
+            "success" if success else "failure",
+            response.status_code,
+            extra={"webhook_id": subscription_id, "status_code": response.status_code},
+        )
+        return {"success": success, "status_code": response.status_code}
+    except requests.RequestException as exc:
+        logger.warning(
+            "Ping to webhook %s failed: %s",
+            subscription_id,
+            exc,
+            extra={"webhook_id": subscription_id},
+        )
+        return {"success": False, "error": str(exc)}
+
+
 # ---------------------------------------------------------------------------
 # Private helpers for dispatch_webhook
 # ---------------------------------------------------------------------------

--- a/django-backend/soroscan/ingest/tests/test_ping_task.py
+++ b/django-backend/soroscan/ingest/tests/test_ping_task.py
@@ -4,10 +4,11 @@ Tests for the ping_webhook Celery task (issue #403).
 import json
 
 import pytest
+import requests
 import responses as responses_lib
 
 from soroscan.ingest.tasks import ping_webhook
-from soroscan.ingest.tests.factories import WebhookSubscriptionFactory, TrackedContractFactory
+from soroscan.ingest.tests.factories import TrackedContractFactory, WebhookSubscriptionFactory
 
 
 @pytest.mark.django_db
@@ -71,7 +72,7 @@ class TestPingWebhookTask:
             rsps.add(
                 responses_lib.POST,
                 webhook.target_url,
-                body=ConnectionError("connection refused"),
+                body=requests.exceptions.ConnectionError("connection refused"),
             )
             result = ping_webhook.run(webhook.id)
 

--- a/django-backend/soroscan/ingest/tests/test_ping_task.py
+++ b/django-backend/soroscan/ingest/tests/test_ping_task.py
@@ -1,0 +1,79 @@
+"""
+Tests for the ping_webhook Celery task (issue #403).
+"""
+import json
+
+import pytest
+import responses as responses_lib
+
+from soroscan.ingest.tasks import ping_webhook
+from soroscan.ingest.tests.factories import WebhookSubscriptionFactory, TrackedContractFactory
+
+
+@pytest.mark.django_db
+class TestPingWebhookTask:
+    def test_ping_success_on_200(self):
+        contract = TrackedContractFactory()
+        webhook = WebhookSubscriptionFactory(contract=contract)
+
+        with responses_lib.RequestsMock() as rsps:
+            rsps.add(responses_lib.POST, webhook.target_url, status=200)
+            result = ping_webhook.run(webhook.id)
+
+        assert result["success"] is True
+        assert result["status_code"] == 200
+
+    def test_ping_failure_on_non_200(self):
+        contract = TrackedContractFactory()
+        webhook = WebhookSubscriptionFactory(contract=contract)
+
+        with responses_lib.RequestsMock() as rsps:
+            rsps.add(responses_lib.POST, webhook.target_url, status=503)
+            result = ping_webhook.run(webhook.id)
+
+        assert result["success"] is False
+        assert result["status_code"] == 503
+
+    def test_ping_sends_correct_payload(self):
+        contract = TrackedContractFactory()
+        webhook = WebhookSubscriptionFactory(contract=contract)
+
+        with responses_lib.RequestsMock() as rsps:
+            rsps.add(responses_lib.POST, webhook.target_url, status=200)
+            ping_webhook.run(webhook.id)
+            request_body = json.loads(rsps.calls[0].request.body)
+
+        assert request_body["type"] == "ping"
+        assert "timestamp" in request_body
+
+    def test_ping_sends_correct_content_type_header(self):
+        contract = TrackedContractFactory()
+        webhook = WebhookSubscriptionFactory(contract=contract)
+
+        with responses_lib.RequestsMock() as rsps:
+            rsps.add(responses_lib.POST, webhook.target_url, status=200)
+            ping_webhook.run(webhook.id)
+            content_type = rsps.calls[0].request.headers["Content-Type"]
+
+        assert content_type == "application/json"
+
+    def test_ping_returns_error_for_missing_subscription(self):
+        result = ping_webhook.run(999999)
+
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_ping_handles_connection_error(self):
+        contract = TrackedContractFactory()
+        webhook = WebhookSubscriptionFactory(contract=contract)
+
+        with responses_lib.RequestsMock() as rsps:
+            rsps.add(
+                responses_lib.POST,
+                webhook.target_url,
+                body=ConnectionError("connection refused"),
+            )
+            result = ping_webhook.run(webhook.id)
+
+        assert result["success"] is False
+        assert "error" in result

--- a/django-backend/soroscan/ingest/tests/test_views.py
+++ b/django-backend/soroscan/ingest/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 import responses
 from django.contrib.auth import get_user_model
@@ -402,13 +404,13 @@ class TestRecordEventView:
 
 @pytest.mark.django_db
 class TestWebhookPingEndpoint:
-    @responses.activate
     def test_ping_queues_task_and_returns_200(self, authenticated_client, contract):
         webhook = WebhookSubscriptionFactory(contract=contract)
-        responses.add(responses.POST, webhook.target_url, status=200)
 
-        url = reverse("webhook-ping", args=[webhook.id])
-        response = authenticated_client.post(url)
+        with patch("soroscan.ingest.views.ping_webhook.delay") as mock_delay:
+            url = reverse("webhook-ping", args=[webhook.id])
+            response = authenticated_client.post(url)
+            mock_delay.assert_called_once_with(webhook.id)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["status"] == "ping_queued"

--- a/django-backend/soroscan/ingest/tests/test_views.py
+++ b/django-backend/soroscan/ingest/tests/test_views.py
@@ -407,7 +407,7 @@ class TestWebhookPingEndpoint:
     def test_ping_queues_task_and_returns_200(self, authenticated_client, contract):
         webhook = WebhookSubscriptionFactory(contract=contract)
 
-        with patch("soroscan.ingest.views.ping_webhook.delay") as mock_delay:
+        with patch("soroscan.ingest.tasks.ping_webhook.delay") as mock_delay:
             url = reverse("webhook-ping", args=[webhook.id])
             response = authenticated_client.post(url)
             mock_delay.assert_called_once_with(webhook.id)

--- a/django-backend/soroscan/ingest/tests/test_views.py
+++ b/django-backend/soroscan/ingest/tests/test_views.py
@@ -401,6 +401,37 @@ class TestRecordEventView:
 
 
 @pytest.mark.django_db
+class TestWebhookPingEndpoint:
+    @responses.activate
+    def test_ping_queues_task_and_returns_200(self, authenticated_client, contract):
+        webhook = WebhookSubscriptionFactory(contract=contract)
+        responses.add(responses.POST, webhook.target_url, status=200)
+
+        url = reverse("webhook-ping", args=[webhook.id])
+        response = authenticated_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "ping_queued"
+        assert response.data["webhook_id"] == webhook.id
+
+    def test_ping_returns_404_for_missing_webhook(self, authenticated_client):
+        url = reverse("webhook-ping", args=[999999])
+        response = authenticated_client.post(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_ping_requires_authentication(self, api_client, contract):
+        webhook = WebhookSubscriptionFactory(contract=contract)
+        url = reverse("webhook-ping", args=[webhook.id])
+        response = api_client.post(url)
+
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+
+@pytest.mark.django_db
 class TestHealthCheck:
     def test_health_check(self, api_client):
         url = reverse("health-check")

--- a/django-backend/soroscan/ingest/views.py
+++ b/django-backend/soroscan/ingest/views.py
@@ -591,6 +591,30 @@ class WebhookSubscriptionViewSet(viewsets.ModelViewSet):
         return Response({"status": "test_webhook_queued"})
 
     @extend_schema(
+        request=None,
+        responses={
+            200: inline_serializer(
+                name="PingWebhookResponse",
+                fields={
+                    "status": serializers.CharField(),
+                    "webhook_id": serializers.IntegerField(),
+                },
+            )
+        },
+    )
+    @action(detail=True, methods=["post"])
+    def ping(self, request, pk=None):
+        """
+        Dispatch a background task that sends a test ping payload to the webhook
+        endpoint.  The task logs whether the target responded with HTTP 200.
+        """
+        from .tasks import ping_webhook
+
+        webhook = self.get_object()
+        ping_webhook.delay(webhook.id)
+        return Response({"status": "ping_queued", "webhook_id": webhook.id})
+
+    @extend_schema(
         request=inline_serializer(
             name="WebhookConditionDryRunRequest",
             fields={


### PR DESCRIPTION
Closes #403

---

- Add POST /api/ingest/webhooks/{id}/ping/ action on WebhookSubscriptionViewSet
- Add ping_webhook Celery task that sends {"type":"ping","timestamp":"..."} to the webhook target URL and logs success/failure by HTTP status code
- Return {"status":"ping_queued","webhook_id":N} immediately from the endpoint
- Tests: unit tests for the task (payload shape, 200/non-200/connection error) and endpoint tests for the REST action