### PR TITLE
feat: add Celery worker health check endpoint

### DIFF
--- a/django-backend/soroscan/health.py
+++ b/django-backend/soroscan/health.py
@@ -7,6 +7,8 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+WORKER_PING_TIMEOUT = 5  # seconds
+
 
 @api_view(["GET"])
 @permission_classes([AllowAny])
@@ -38,3 +40,27 @@ def readiness_view(request):
         return Response({"status": "not_ready", "errors": errors}, status=503)
 
     return Response({"status": "ready"})
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def workers_health_view(request):
+    """Check that at least one Celery worker is responding."""
+    from soroscan.celery import app as celery_app
+
+    try:
+        inspector = celery_app.control.inspect(timeout=WORKER_PING_TIMEOUT)
+        ping_result = inspector.ping() or {}
+    except Exception as e:
+        return Response(
+            {"status": "error", "detail": f"Celery inspect failed: {e}"},
+            status=503,
+        )
+
+    if not ping_result:
+        return Response(
+            {"status": "no_workers", "detail": "No Celery workers responded"},
+            status=503,
+        )
+
+    return Response({"status": "ok", "workers": list(ping_result.keys())})

--- a/django-backend/soroscan/ingest/tests/test_health.py
+++ b/django-backend/soroscan/ingest/tests/test_health.py
@@ -62,3 +62,59 @@ class TestReadinessView:
         assert response.data["status"] == "not_ready"
         assert any("redis" in e for e in response.data["errors"])
         assert response["X-SoroScan-Version"] == settings.SOFTWARE_VERSION
+
+
+@pytest.mark.django_db
+class TestWorkersHealthView:
+    def test_workers_ok_when_ping_returns_results(self, api_client, monkeypatch):
+        fake_ping = {"celery@worker1": {"ok": "pong"}}
+
+        class FakeInspector:
+            def ping(self):
+                return fake_ping
+
+        class FakeControl:
+            def inspect(self, timeout=None):
+                return FakeInspector()
+
+        import soroscan.celery as celery_module
+        monkeypatch.setattr(celery_module.app, "control", FakeControl())
+
+        url = reverse("workers-health")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "ok"
+        assert "celery@worker1" in response.data["workers"]
+
+    def test_workers_503_when_no_workers_respond(self, api_client, monkeypatch):
+        class FakeInspector:
+            def ping(self):
+                return {}
+
+        class FakeControl:
+            def inspect(self, timeout=None):
+                return FakeInspector()
+
+        import soroscan.celery as celery_module
+        monkeypatch.setattr(celery_module.app, "control", FakeControl())
+
+        url = reverse("workers-health")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.data["status"] == "no_workers"
+
+    def test_workers_503_when_inspect_raises(self, api_client, monkeypatch):
+        class FakeControl:
+            def inspect(self, timeout=None):
+                raise Exception("Broker unreachable")
+
+        import soroscan.celery as celery_module
+        monkeypatch.setattr(celery_module.app, "control", FakeControl())
+
+        url = reverse("workers-health")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.data["status"] == "error"

--- a/django-backend/soroscan/urls.py
+++ b/django-backend/soroscan/urls.py
@@ -15,7 +15,7 @@ from rest_framework_simplejwt.views import (
 )
 
 from soroscan.graphql_views import ThrottledGraphQLView
-from soroscan.health import health_view, readiness_view
+from soroscan.health import health_view, readiness_view, workers_health_view
 from soroscan.meta_views import db_pool_stats_view
 from soroscan.ingest.views import audit_trail_view, contract_status, rate_limit_analytics_view
 from soroscan.ingest.schema import schema
@@ -34,6 +34,7 @@ urlpatterns = [
 
     path("health/", health_view, name="health"),
     path("ready/", readiness_view, name="readiness"),
+    path("api/health/workers/", workers_health_view, name="workers-health"),
 
     path("admin/", admin.site.urls),
     path("api/audit-trail/", audit_trail_view, name="audit-trail"),


### PR DESCRIPTION
## Summary

Closes #412

### Changes
- **`GET /api/health/workers/`** — calls `celery.control.inspect(timeout=5).ping()`
- Returns `200 {status: ok, workers: [...]}` when at least one worker responds
- Returns `503 {status: no_workers}` when ping returns empty
- Returns `503 {status: error}` when broker is unreachable (graceful timeout)
- Tests cover all three cases via monkeypatching in `test_health.py`

### Files changed
- `django-backend/soroscan/health.py`
- `django-backend/soroscan/urls.py`
- `django-backend/soroscan/ingest/tests/test_health.py`