### PR TITLE
feat: log warning on startup if SECRET_KEY is weak or default

### DIFF
--- a/django-backend/soroscan/ingest/tests/test_secret_key_warning.py
+++ b/django-backend/soroscan/ingest/tests/test_secret_key_warning.py
@@ -1,0 +1,33 @@
+"""Tests for SECRET_KEY startup warning (issue #423)."""
+import logging
+import importlib
+import sys
+
+
+def _reload_settings_with_key(monkeypatch, key: str):
+    """Reload soroscan.settings with a patched SECRET_KEY env var."""
+    monkeypatch.setenv("SECRET_KEY", key)
+    # Remove cached module so settings re-evaluates
+    mod_name = "soroscan.settings"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+    return importlib.import_module(mod_name)
+
+
+def test_warns_for_short_key(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING, logger="soroscan.security"):
+        _reload_settings_with_key(monkeypatch, "short")
+    assert any("SECRET_KEY" in r.message for r in caplog.records)
+
+
+def test_warns_for_known_default(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING, logger="soroscan.security"):
+        _reload_settings_with_key(monkeypatch, "django-insecure-change-this-in-production")
+    assert any("SECRET_KEY" in r.message for r in caplog.records)
+
+
+def test_no_warning_for_strong_key(monkeypatch, caplog):
+    strong = "a" * 60  # 60 chars, not a known default
+    with caplog.at_level(logging.WARNING, logger="soroscan.security"):
+        _reload_settings_with_key(monkeypatch, strong)
+    assert not any("SECRET_KEY" in r.message for r in caplog.records)

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -56,6 +56,20 @@ if not _running_tests:
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY", default="django-insecure-change-this-in-production")
 
+# Warn on startup if SECRET_KEY is weak or a known default
+_KNOWN_WEAK_KEYS = {
+    "django-insecure-change-this-in-production",
+    "secret",
+    "changeme",
+    "insecure",
+}
+if len(SECRET_KEY) < 50 or SECRET_KEY in _KNOWN_WEAK_KEYS:
+    import logging as _logging
+    _logging.getLogger("soroscan.security").warning(
+        "SECRET_KEY is too short or matches a known default. "
+        "Set a strong, unique SECRET_KEY before deploying to production."
+    )
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 


### PR DESCRIPTION
## Summary

Closes #423

### Changes
- After `SECRET_KEY` is defined in `settings.py`, checks if it is shorter than 50 characters or matches a known insecure default
- Logs a `WARNING` via the `soroscan.security` logger — does not block startup
- Known defaults checked: `django-insecure-change-this-in-production`, `secret`, `changeme`, `insecure`
- Tests in `test_secret_key_warning.py` verify warning appears for weak/default keys and is absent for strong keys

### Files changed
- `django-backend/soroscan/settings.py`
- `django-backend/soroscan/ingest/tests/test_secret_key_warning.py`