### PR TITLE
feat: add empty state illustration for no contracts

### DIFF
--- a/soroscan-frontend/app/contracts/components/ContractEmptyState.tsx
+++ b/soroscan-frontend/app/contracts/components/ContractEmptyState.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/terminal/Button";
+
+interface ContractEmptyStateProps {
+  onRegister: () => void;
+}
+
+/**
+ * Shown inside the TRACKED_CONTRACTS card when the user has no contracts yet.
+ * Renders an animated SVG icon, a friendly message, and a CTA button.
+ * Fully responsive — stacks gracefully on small screens.
+ */
+export function ContractEmptyState({ onRegister }: ContractEmptyStateProps) {
+  return (
+    <div
+      className="
+        flex flex-col items-center justify-center gap-6
+        py-16 px-4 sm:py-20
+        font-terminal-mono
+      "
+      role="status"
+      aria-label="No contracts registered"
+    >
+      {/* ── Animated terminal-style icon ── */}
+      <div className="relative flex items-center justify-center">
+        {/* Outer pulsing ring */}
+        <span
+          className="
+            absolute inline-flex h-24 w-24 rounded-full
+            border border-terminal-green/20
+            animate-ping
+          "
+          aria-hidden="true"
+        />
+        {/* Static ring */}
+        <span
+          className="
+            relative inline-flex items-center justify-center
+            h-20 w-20 rounded-full
+            border border-terminal-green/30
+            bg-terminal-green/5
+          "
+          aria-hidden="true"
+        >
+          {/* Contract / file-code SVG icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-9 w-9 text-terminal-green"
+            aria-hidden="true"
+          >
+            {/* Document outline */}
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            {/* Code lines */}
+            <line x1="8" y1="13" x2="16" y2="13" />
+            <line x1="8" y1="17" x2="12" y2="17" />
+            {/* Bracket hints */}
+            <polyline points="10 9 8 11 10 13" />
+          </svg>
+        </span>
+      </div>
+
+      {/* ── Copy ── */}
+      <div className="text-center space-y-2 max-w-sm">
+        <p className="text-terminal-green text-lg tracking-widest uppercase">
+          No contracts found
+        </p>
+        <p className="text-terminal-gray text-sm leading-relaxed">
+          You haven&apos;t registered any Soroban contracts yet.
+          <br className="hidden sm:block" />
+          Register a contract to start indexing events.
+        </p>
+      </div>
+
+      {/* ── Horizontal dashed separator ── */}
+      <div
+        className="w-full max-w-xs border-t border-dashed border-terminal-green/20"
+        aria-hidden="true"
+      />
+
+      {/* ── CTA ── */}
+      <Button
+        id="empty-state-register-contract"
+        variant="primary"
+        size="lg"
+        onClick={onRegister}
+        aria-label="Register your first contract"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-4 w-4"
+          aria-hidden="true"
+        >
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        Register Contract
+      </Button>
+
+      {/* ── Subtle hint ── */}
+      <p className="text-terminal-gray/50 text-xs tracking-wider">
+        $ soroscan contracts register --id &lt;CONTRACT_ID&gt;
+      </p>
+    </div>
+  );
+}

--- a/soroscan-frontend/app/contracts/components/ContractTable.tsx
+++ b/soroscan-frontend/app/contracts/components/ContractTable.tsx
@@ -12,13 +12,15 @@ import {
 } from "@/components/terminal/Table";
 import { Button } from "@/components/terminal/Button";
 import type { Contract } from "@/components/ingest/contract-types";
+import { ContractEmptyState } from "./ContractEmptyState";
 
 interface ContractTableProps {
   contracts: Contract[];
   onDelete: (id: string) => void;
+  onRegister: () => void;
 }
 
-export function ContractTable({ contracts, onDelete }: ContractTableProps) {
+export function ContractTable({ contracts, onDelete, onRegister }: ContractTableProps) {
   const router = useRouter();
 
   const handleRowClick = (id: string) => {
@@ -26,11 +28,7 @@ export function ContractTable({ contracts, onDelete }: ContractTableProps) {
   };
 
   if (contracts.length === 0) {
-    return (
-      <div className="text-center text-terminal-gray py-8 font-terminal-mono">
-        No contracts registered. Click &quot;Register Contract&quot; to add one.
-      </div>
-    );
+    return <ContractEmptyState onRegister={onRegister} />;
   }
 
   return (

--- a/soroscan-frontend/app/contracts/page.tsx
+++ b/soroscan-frontend/app/contracts/page.tsx
@@ -96,7 +96,11 @@ export default function ContractsPage() {
               LOADING...
             </div>
           ) : (
-            <ContractTable contracts={contracts} onDelete={handleDeleteClick} />
+            <ContractTable
+                contracts={contracts}
+                onDelete={handleDeleteClick}
+                onRegister={() => setIsRegisterModalOpen(true)}
+              />
           )}
         </Card>
 


### PR DESCRIPTION
## What was done

Icon — animated terminal-style "document with code" SVG inside a pulsing ring, rendered entirely in CSS (animate-ping outer ring + static inner circle), no image file needed
Message — NO CONTRACTS FOUND headline + descriptive subtitle explaining what to do next
Create contract link — primary Register Contract button that directly opens the RegisterModal (same as the header button)
CLI hint — subtle $ soroscan contracts register --id <CONTRACT_ID> line reinforces the terminal aesthetic
Mobile friendly — stacks vertically with flex-col, text-center, responsive padding (py-16 sm:py-20), and the subtitle line-break uses hidden sm:block so it reflows neatly on small screens
Accessibility — role="status", aria-label on the container, aria-hidden on decorative SVGs, unique id on the CTA button


Close #602