### PR TITLE
Implement production-safe slow query logging middleware 

### DIFF
--- a/django-backend/soroscan/perf_logger.py
+++ b/django-backend/soroscan/perf_logger.py
@@ -1,0 +1,59 @@
+import logging
+import time
+from contextlib import ExitStack
+
+from django.conf import settings
+from django.db import connections
+
+logger = logging.getLogger("django.performance.database")
+
+
+class SlowQueryLoggerMiddleware:
+    """
+    Middleware that monitors and logs database queries exceeding a configurable execution time threshold.
+    Uses django.db.connection.execute_wrapper for accurate timing and minimal overhead.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Dynamically read threshold, defaulting to 1.0 seconds
+        threshold = getattr(settings, "DATABASE_SLOW_QUERY_THRESHOLD", 1.0)
+        
+        with ExitStack() as stack:
+            # We apply the execute_wrapper to all configured databases to support multi-DB setups
+            for alias in connections:
+                # We need to capture the current alias inside the loop securely.
+                def make_wrapper(db_alias):
+                    def _execute_wrapper(execute, sql, params, many, context):
+                        start_time = time.monotonic()
+                        try:
+                            return execute(sql, params, many, context)
+                        finally:
+                            duration = time.monotonic() - start_time
+                            if duration > threshold:
+                                safe_params = str(params)[:1000] if params else ""
+                                try:
+                                    logger.warning(
+                                        "Slow query detected: SQL [%s] Execution Time: [%.4fs] DB Alias: [%s]",
+                                        sql,
+                                        duration,
+                                        db_alias,
+                                        extra={
+                                            "duration": round(duration, 4),
+                                            "sql": sql,
+                                            "params": safe_params,
+                                            "db_alias": db_alias,
+                                        },
+                                    )
+                                except Exception:
+                                    # Never fail the user request due to logging exceptions
+                                    pass
+                    return _execute_wrapper
+                
+                stack.enter_context(connections[alias].execute_wrapper(make_wrapper(alias)))
+            
+            response = self.get_response(request)
+
+        return response

--- a/django-backend/soroscan/settings.py
+++ b/django-backend/soroscan/settings.py
@@ -112,6 +112,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "soroscan.middleware.RequestIdMiddleware",
     "soroscan.middleware.PlatformVersionMiddleware",
+    "soroscan.perf_logger.SlowQueryLoggerMiddleware",
     "soroscan.middleware.SlowQueryMiddleware",
     "soroscan.middleware.ApiDeprecationMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -433,6 +434,7 @@ LOGGING = {
 # Slow-query logging (Issue: perf monitoring)
 # ---------------------------------------------------------------------------
 LOGGING_SLOW_QUERIES_THRESHOLD_MS = env.int("SLOW_QUERY_THRESHOLD_MS", default=100)
+DATABASE_SLOW_QUERY_THRESHOLD = env.float("DATABASE_SLOW_QUERY_THRESHOLD", default=1.0)
 
 # Ensure log directories exist before configuring handlers
 _LOG_DIR = BASE_DIR / "logs"
@@ -457,6 +459,11 @@ LOGGING["loggers"]["soroscan.slow_queries"] = {
 LOGGING["loggers"]["soroscan.migrate"] = {
     "handlers": ["console"],
     "level": "INFO",
+    "propagate": False,
+}
+LOGGING["loggers"]["django.performance.database"] = {
+    "handlers": ["console"],
+    "level": "WARNING",
     "propagate": False,
 }
 

--- a/django-backend/soroscan/test_perf_logger.py
+++ b/django-backend/soroscan/test_perf_logger.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings, RequestFactory
+from django.db import connection
+from django.http import HttpResponse
+
+from soroscan.perf_logger import SlowQueryLoggerMiddleware
+
+
+class MockTimeSlow:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        # First call (start) returns 0.0, second call (end) returns 1.1. Duration = 1.1s
+        return 0.0 if self.calls % 2 != 0 else 1.1
+
+
+class MockTimeFast:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        # First call (start) returns 0.0, second call (end) returns 0.9. Duration = 0.9s
+        return 0.0 if self.calls % 2 != 0 else 0.9
+
+
+class SlowQueryLoggerMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(DATABASE_SLOW_QUERY_THRESHOLD=1.0)
+    def test_slow_query_logged(self):
+        def get_response(request):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+            return HttpResponse("OK")
+
+        middleware = SlowQueryLoggerMiddleware(get_response)
+        request = self.factory.get("/")
+
+        with patch("soroscan.perf_logger.time.monotonic", side_effect=MockTimeSlow()):
+            with self.assertLogs("django.performance.database", level="WARNING") as cm:
+                middleware(request)
+
+        self.assertTrue(any("Slow query detected: SQL" in log for log in cm.output))
+        self.assertTrue(any("1.1000s" in log for log in cm.output))
+
+    @override_settings(DATABASE_SLOW_QUERY_THRESHOLD=1.0)
+    def test_fast_query_not_logged(self):
+        def get_response(request):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+            return HttpResponse("OK")
+
+        middleware = SlowQueryLoggerMiddleware(get_response)
+        request = self.factory.get("/")
+
+        with patch("soroscan.perf_logger.time.monotonic", side_effect=MockTimeFast()):
+            # Using try-except for AssertionError which assertLogs raises when no logs are emitted
+            try:
+                with self.assertLogs("django.performance.database", level="WARNING"):
+                    middleware(request)
+            except AssertionError:
+                pass
+            else:
+                self.fail("assertLogs should have raised AssertionError because no logs were expected")


### PR DESCRIPTION
Closes #586

---

 # Implement production-safe slow query logging middleware 

  ### Description

  This PR implements a lightweight, production-safe Django middleware ( SlowQueryLoggerMiddleware ) to monitor,
  identify, and log database queries that exceed a configurable execution time threshold.

  ### Changes Included

  • Middleware Implementation: Added  SlowQueryLoggerMiddleware  in  django-backend/soroscan/perf_logger.py  which
  dynamically wraps  django.db.connection.execute_wrapper . This provides highly accurate timing and minimal overhead
  across all active database connections.
  • Settings Updates:
      • Exposed a  DATABASE_SLOW_QUERY_THRESHOLD  setting (defaulting to 1.0 seconds).
      • Configured a dedicated logger ( django.performance.database ) to emit  WARNING  level messages for slow queries
      without cluttering standard application logs.
      • Registered the new middleware in the  MIDDLEWARE  array.
  • Testing: Added isolated unit tests ( django-backend/soroscan/test_perf_logger.py ) to verify the generation of
  warnings on slow queries and the suppression of warnings on fast queries, utilizing mocked monotonic clocks and      
  assertLogs .

  ### Motivation

  Tracking down slow queries is critical for performance monitoring and reliability. Relying on                        
  django.db.connection.queries  in production environments is unsafe as it silently fails or causes memory leaks when  
  DEBUG=False . By utilizing  execute_wrapper , we gain a safe, thread-local hook into database cursor execution,
  allowing us to actively track query latency and parameterize bottlenecks seamlessly.

  ### Testing Instructions

  1. Run the test suite:  python -m pytest django-backend/soroscan/test_perf_logger.py 
  2. Test boundaries manually by overriding  DATABASE_SLOW_QUERY_THRESHOLD=0.001  in your local  .env  and loading any
  dashboard page. You should see slow query warnings emitted in the console.