### PR TITLE
feat: add shared sort direction indicators for table headers

### DIFF
--- a/soroscan-frontend/__tests__/SortDirectionIndicator.test.tsx
+++ b/soroscan-frontend/__tests__/SortDirectionIndicator.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SortDirectionIndicator } from "@/components/terminal/Table";
+
+describe("SortDirectionIndicator", () => {
+  it("shows muted up arrow when column is not active", () => {
+    const { container } = render(
+      <SortDirectionIndicator active={false} direction="asc" />,
+    );
+    const icon = container.querySelector("svg");
+    expect(icon).toHaveClass("opacity-20");
+  });
+
+  it("shows up arrow for ascending active sort", () => {
+    const { container } = render(
+      <SortDirectionIndicator active={true} direction="asc" />,
+    );
+    const icon = container.querySelector("svg");
+    expect(icon).toBeTruthy();
+    expect(icon?.classList.contains("opacity-20")).toBe(false);
+  });
+
+  it("shows down arrow for descending active sort", () => {
+    const { container } = render(
+      <SortDirectionIndicator active={true} direction="desc" />,
+    );
+    const icon = container.querySelector("svg");
+    expect(icon).toBeTruthy();
+    expect(icon?.classList.contains("opacity-20")).toBe(false);
+  });
+});

--- a/soroscan-frontend/app/webhooks/[id]/components/DeliveryLog.tsx
+++ b/soroscan-frontend/app/webhooks/[id]/components/DeliveryLog.tsx
@@ -1,11 +1,15 @@
 "use client"
 
 import * as React from "react"
-import { ChevronDown, ChevronUp, ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
 import {
   Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption,
+  SortDirectionIndicator,
+  type SortDirection,
 } from "@/components/terminal/Table"
-import type { DeliveryLog, SortField, SortDir, StatusFilter } from "../../types"
+import type { DeliveryLog, SortField, StatusFilter } from "../../types"
+
+type SortDir = SortDirection
 
 interface DeliveryLogProps {
   logs: DeliveryLog[]
@@ -124,9 +128,10 @@ export function DeliveryLog({ logs }: DeliveryLogProps) {
                   >
                     <span className="inline-flex items-center gap-1">
                       TIMESTAMP
-                      {sortField === "timestamp"
-                        ? sortDir === "asc" ? <ChevronUp size={10} /> : <ChevronDown size={10} />
-                        : <ChevronUp size={10} className="opacity-20" />}
+                      <SortDirectionIndicator
+                        active={sortField === "timestamp"}
+                        direction={sortDir}
+                      />
                     </span>
                   </TableHead>
                   <TableHead className="hidden sm:table-cell">EVENT_TYPE</TableHead>
@@ -136,9 +141,10 @@ export function DeliveryLog({ logs }: DeliveryLogProps) {
                   >
                     <span className="inline-flex items-center gap-1">
                       STATUS
-                      {sortField === "statusCode"
-                        ? sortDir === "asc" ? <ChevronUp size={10} /> : <ChevronDown size={10} />
-                        : <ChevronUp size={10} className="opacity-20" />}
+                      <SortDirectionIndicator
+                        active={sortField === "statusCode"}
+                        direction={sortDir}
+                      />
                     </span>
                   </TableHead>
                   <TableHead
@@ -147,9 +153,10 @@ export function DeliveryLog({ logs }: DeliveryLogProps) {
                   >
                     <span className="inline-flex items-center gap-1">
                       RESP_TIME
-                      {sortField === "responseTimeMs"
-                        ? sortDir === "asc" ? <ChevronUp size={10} /> : <ChevronDown size={10} />
-                        : <ChevronUp size={10} className="opacity-20" />}
+                      <SortDirectionIndicator
+                        active={sortField === "responseTimeMs"}
+                        direction={sortDir}
+                      />
                     </span>
                   </TableHead>
                   <TableHead
@@ -158,9 +165,10 @@ export function DeliveryLog({ logs }: DeliveryLogProps) {
                   >
                     <span className="inline-flex items-center gap-1">
                       ATTEMPT
-                      {sortField === "attempt"
-                        ? sortDir === "asc" ? <ChevronUp size={10} /> : <ChevronDown size={10} />
-                        : <ChevronUp size={10} className="opacity-20" />}
+                      <SortDirectionIndicator
+                        active={sortField === "attempt"}
+                        direction={sortDir}
+                      />
                     </span>
                   </TableHead>
                   <TableHead>ERROR_MSG</TableHead>

--- a/soroscan-frontend/app/webhooks/components/WebhookTable.tsx
+++ b/soroscan-frontend/app/webhooks/components/WebhookTable.tsx
@@ -2,9 +2,11 @@
 
 import * as React from "react"
 import Link from "next/link"
-import { Trash2, FlaskConical, ChevronUp, ChevronDown } from "lucide-react"
+import { Trash2, FlaskConical } from "lucide-react"
 import {
   Table, TableHeader, TableBody, TableRow, TableHead, TableCell,
+  SortDirectionIndicator,
+  type SortDirection,
 } from "@/components/terminal/Table"
 import { Button } from "@/components/terminal/Button"
 import type { Webhook, WebhookStatus } from "../types"
@@ -18,7 +20,7 @@ interface WebhookTableProps {
 }
 
 type SortField = "url" | "status" | "successRate" | "lastDelivery"
-type SortDir = "asc" | "desc"
+type SortDir = SortDirection
 
 function StatusBadge({ status }: { status: WebhookStatus }) {
   const map: Record<WebhookStatus, { dot: string; label: string; text: string }> = {
@@ -45,11 +47,6 @@ function SuccessBar({ rate }: { rate: number }) {
       <span className="text-[10px]">{rate.toFixed(1)}%</span>
     </div>
   )
-}
-
-function SortIcon({ active, dir }: { field: string; active: boolean; dir: SortDir }) {
-  if (!active) return <ChevronUp size={10} className="opacity-20" />
-  return dir === "asc" ? <ChevronUp size={10} /> : <ChevronDown size={10} />
 }
 
 export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult }: WebhookTableProps) {
@@ -93,7 +90,7 @@ export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult
             >
               <span className="inline-flex items-center gap-1">
                 STATUS
-                <SortIcon field="status" active={sortField === "status"} dir={sortDir} />
+                <SortDirectionIndicator active={sortField === "status"} direction={sortDir} />
               </span>
             </TableHead>
             <TableHead
@@ -102,7 +99,7 @@ export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult
             >
               <span className="inline-flex items-center gap-1">
                 ENDPOINT_URL
-                <SortIcon field="url" active={sortField === "url"} dir={sortDir} />
+                <SortDirectionIndicator active={sortField === "url"} direction={sortDir} />
               </span>
             </TableHead>
             <TableHead className="hidden md:table-cell">EVENT_TYPES</TableHead>
@@ -112,7 +109,7 @@ export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult
             >
               <span className="inline-flex items-center gap-1">
                 SUCCESS
-                <SortIcon field="successRate" active={sortField === "successRate"} dir={sortDir} />
+                <SortDirectionIndicator active={sortField === "successRate"} direction={sortDir} />
               </span>
             </TableHead>
             <TableHead
@@ -121,7 +118,7 @@ export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult
             >
               <span className="inline-flex items-center gap-1">
                 LAST_DELIVERY
-                <SortIcon field="lastDelivery" active={sortField === "lastDelivery"} dir={sortDir} />
+                <SortDirectionIndicator active={sortField === "lastDelivery"} direction={sortDir} />
               </span>
             </TableHead>
             <TableHead>ACTIONS</TableHead>

--- a/soroscan-frontend/components/terminal/Table.tsx
+++ b/soroscan-frontend/components/terminal/Table.tsx
@@ -1,5 +1,27 @@
 import * as React from "react"
+import { ChevronDown, ChevronUp } from "lucide-react"
 import { cn } from "@/lib/utils"
+
+export type SortDirection = "asc" | "desc"
+
+interface SortDirectionIndicatorProps {
+  active: boolean
+  direction: SortDirection
+  className?: string
+}
+
+/** Up/down arrows for sortable table headers. */
+export function SortDirectionIndicator({
+  active,
+  direction,
+  className,
+}: SortDirectionIndicatorProps) {
+  if (!active) {
+    return <ChevronUp size={10} className={cn("opacity-20", className)} aria-hidden="true" />
+  }
+  const Icon = direction === "asc" ? ChevronUp : ChevronDown
+  return <Icon size={10} className={className} aria-hidden="true" />
+}
 
 const Table = React.forwardRef<
   HTMLTableElement,


### PR DESCRIPTION
Extract SortDirectionIndicator into the terminal Table module and use it in webhook tables so sort state is shown consistently with up/down arrows.

closes #605 