### PR TITLE
feat: add GET /api/webhooks/failures/ for failed delivery logs

### DIFF
--- a/django-backend/soroscan/ingest/tests/test_webhook_failures.py
+++ b/django-backend/soroscan/ingest/tests/test_webhook_failures.py
@@ -1,0 +1,99 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from soroscan.ingest.models import WebhookDeliveryLog
+
+from .factories import (
+    UserFactory,
+    WebhookDeliveryLogFactory,
+    WebhookSubscriptionFactory,
+)
+
+
+@pytest.fixture
+def api_client():
+    from rest_framework.test import APIClient
+
+    return APIClient()
+
+
+@pytest.fixture
+def authenticated_client(api_client):
+    user = UserFactory()
+    api_client.force_authenticate(user=user)
+    return api_client
+
+
+@pytest.mark.django_db
+class TestWebhookFailuresEndpoint:
+    def test_requires_authentication(self, api_client):
+        url = reverse("webhook-failures")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_returns_last_50_failed_deliveries(self, authenticated_client):
+        sub = WebhookSubscriptionFactory(target_url="https://example.com/hook")
+
+        for i in range(55):
+            WebhookDeliveryLogFactory(
+                subscription=sub,
+                success=False,
+                status_code=500,
+                error=f"failure {i}",
+            )
+        WebhookDeliveryLogFactory(subscription=sub, success=True, status_code=200, error="")
+
+        url = reverse("webhook-failures")
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data["results"]
+        assert len(results) == 50
+        assert all(item["http_status_code"] == 500 for item in results)
+        assert all(item["url"] == "https://example.com/hook" for item in results)
+        assert "failure" in results[0]["error_message"]
+
+    def test_filters_by_subscription_id(self, authenticated_client):
+        sub_a = WebhookSubscriptionFactory(target_url="https://a.example/hook")
+        sub_b = WebhookSubscriptionFactory(target_url="https://b.example/hook")
+
+        WebhookDeliveryLogFactory(
+            subscription=sub_a,
+            success=False,
+            status_code=502,
+            error="a failed",
+        )
+        WebhookDeliveryLogFactory(
+            subscription=sub_b,
+            success=False,
+            status_code=503,
+            error="b failed",
+        )
+
+        url = reverse("webhook-failures")
+        response = authenticated_client.get(url, {"subscription_id": sub_a.id})
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data["results"]
+        assert len(results) == 1
+        assert results[0]["subscription_id"] == sub_a.id
+        assert results[0]["url"] == "https://a.example/hook"
+        assert results[0]["error_message"] == "a failed"
+        assert results[0]["http_status_code"] == 502
+
+    def test_invalid_subscription_id_returns_400(self, authenticated_client):
+        url = reverse("webhook-failures")
+        response = authenticated_client.get(url, {"subscription_id": "abc"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_excludes_successful_deliveries(self, authenticated_client):
+        sub = WebhookSubscriptionFactory()
+        WebhookDeliveryLogFactory(subscription=sub, success=True, status_code=200)
+
+        url = reverse("webhook-failures")
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["results"] == []
+        assert WebhookDeliveryLog.objects.filter(success=False).count() == 0

--- a/django-backend/soroscan/ingest/views.py
+++ b/django-backend/soroscan/ingest/views.py
@@ -42,6 +42,7 @@ from .models import (
     Team,
     TeamMembership,
     TrackedContract,
+    WebhookDeliveryLog,
     WebhookSubscription,
 )
 from .cache_utils import get_cached_contract
@@ -1439,6 +1440,79 @@ def compliance_export_view(request):
     )
     response["Content-Disposition"] = 'attachment; filename="compliance_audit.csv"'
     return response
+
+
+# ---------------------------------------------------------------------------
+# Issue #472: Failed webhook delivery logs
+# ---------------------------------------------------------------------------
+
+@extend_schema(
+    parameters=[
+        inline_serializer(
+            name="WebhookFailuresParams",
+            fields={
+                "subscription_id": serializers.IntegerField(required=False),
+            },
+        )
+    ],
+    responses={
+        200: inline_serializer(
+            name="WebhookFailuresResponse",
+            fields={
+                "results": serializers.ListField(
+                    child=inline_serializer(
+                        name="WebhookFailureEntry",
+                        fields={
+                            "id": serializers.IntegerField(),
+                            "subscription_id": serializers.IntegerField(),
+                            "url": serializers.CharField(),
+                            "error_message": serializers.CharField(),
+                            "http_status_code": serializers.IntegerField(allow_null=True),
+                            "timestamp": serializers.DateTimeField(),
+                        },
+                    )
+                ),
+            },
+        )
+    },
+)
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def webhook_failures_view(request):
+    """
+    GET /api/webhooks/failures/
+
+    Return the last 50 failed webhook delivery attempts. Optionally filter by
+    subscription_id query parameter.
+    """
+    qs = (
+        WebhookDeliveryLog.objects.filter(success=False)
+        .select_related("subscription")
+        .order_by("-timestamp")
+    )
+
+    subscription_id = request.query_params.get("subscription_id")
+    if subscription_id is not None:
+        if not str(subscription_id).isdigit():
+            return Response(
+                {"detail": "subscription_id must be a positive integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        qs = qs.filter(subscription_id=int(subscription_id))
+
+    logs = qs[:50]
+    results = [
+        {
+            "id": log.id,
+            "subscription_id": log.subscription_id,
+            "url": log.subscription.target_url,
+            "error_message": log.error,
+            "http_status_code": log.status_code,
+            "timestamp": log.timestamp,
+        }
+        for log in logs
+    ]
+    return Response({"results": results})
 
 
 # ---------------------------------------------------------------------------

--- a/django-backend/soroscan/urls.py
+++ b/django-backend/soroscan/urls.py
@@ -17,7 +17,12 @@ from rest_framework_simplejwt.views import (
 from soroscan.graphql_views import ThrottledGraphQLView
 from soroscan.health import health_view, readiness_view
 from soroscan.meta_views import db_pool_stats_view
-from soroscan.ingest.views import audit_trail_view, contract_status, rate_limit_analytics_view
+from soroscan.ingest.views import (
+    audit_trail_view,
+    contract_status,
+    rate_limit_analytics_view,
+    webhook_failures_view,
+)
 from soroscan.ingest.schema import schema
 from soroscan.dev_summary_view import dev_summary_view
 
@@ -41,6 +46,7 @@ urlpatterns = [
     path("api/analytics/rate-limits/", rate_limit_analytics_view, name="rate-limit-analytics"),
     path("api/meta/db-pool/", db_pool_stats_view, name="db-pool-stats"),
     path("api/dev/summary/", dev_summary_view, name="dev-summary"),
+    path("api/webhooks/failures/", webhook_failures_view, name="webhook-failures"),
     path("api/ingest/", include("soroscan.ingest.urls")),
     path("graphql/", ThrottledGraphQLView.as_view(schema=schema)),
     # JWT Authentication

--- a/django-backend/soroscan/urls_test.py
+++ b/django-backend/soroscan/urls_test.py
@@ -11,7 +11,7 @@ from django.urls import include, path
 
 from soroscan.health import health_view, readiness_view
 from soroscan.meta_views import db_pool_stats_view
-from soroscan.ingest.views import contract_status, rate_limit_analytics_view
+from soroscan.ingest.views import contract_status, rate_limit_analytics_view, webhook_failures_view
 from soroscan.dev_summary_view import dev_summary_view
 
 
@@ -35,6 +35,7 @@ urlpatterns = [
     path("api/analytics/rate-limits/", rate_limit_analytics_view, name="rate-limit-analytics"),
     path("api/meta/db-pool/", db_pool_stats_view, name="db-pool-stats"),
     path("api/dev/summary/", dev_summary_view, name="dev-summary"),
+    path("api/webhooks/failures/", webhook_failures_view, name="webhook-failures"),
     path("api/ingest/", include("soroscan.ingest.urls")),
 ]
 


### PR DESCRIPTION
Expose the last 50 failed webhook attempts with optional subscription filtering so operators can diagnose delivery issues without admin access.

closes #472 