### PR TITLE
test: strengthen toast notification coverage for all types

### DIFF
--- a/soroscan-frontend/__tests__/toast.test.tsx
+++ b/soroscan-frontend/__tests__/toast.test.tsx
@@ -98,6 +98,29 @@ describe("Toast System", () => {
     expect(toasts.length).toBe(2);
   });
 
+  it.each([
+    ["success", "status"],
+    ["error", "alert"],
+    ["info", "status"],
+    ["warning", "status"],
+  ] as const)(
+    "renders %s toast with correct accessibility role",
+    (type, role) => {
+      render(
+        <ToastProvider>
+          <div />
+        </ToastProvider>,
+      );
+
+      act(() => {
+        showToast(`${type} message`, type, `${type} title`);
+      });
+
+      expect(screen.getByText(`${type} title`)).toBeInTheDocument();
+      expect(screen.getByRole(role)).toBeInTheDocument();
+    },
+  );
+
   it("works with global showToast helper", () => {
     render(
       <ToastProvider>

--- a/soroscan-frontend/context/ToastContext.tsx
+++ b/soroscan-frontend/context/ToastContext.tsx
@@ -18,7 +18,7 @@
   X,
 } from "lucide-react";
 
-type ToastType = "success" | "error" | "info" | "warning";
+export type ToastType = "success" | "error" | "info" | "warning";
 
  interface Toast {
   id: string;


### PR DESCRIPTION
Export ToastType and add per-type accessibility tests to document the success, error, info, and warning toast behaviors for issue #273.


closes #273 