### PR TITLE
feat: implement #540 #541 #568 #574 frontend components

### DIFF
--- a/soroscan-frontend/__tests__/advanced-filter-builder.test.tsx
+++ b/soroscan-frontend/__tests__/advanced-filter-builder.test.tsx
@@ -1,0 +1,168 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { AdvancedFilterBuilder } from "@/components/ui/AdvancedFilterBuilder"
+
+const FIELDS = ["contractId", "eventType", "ledger", "value"]
+const mockOnChange = jest.fn()
+const mockOnApply  = jest.fn()
+
+beforeEach(() => {
+  mockOnChange.mockClear()
+  mockOnApply.mockClear()
+  localStorage.clear()
+})
+
+function renderBuilder(overrides = {}) {
+  return render(
+    <AdvancedFilterBuilder
+      fields={FIELDS}
+      onChange={mockOnChange}
+      onApply={mockOnApply}
+      storageKey="test_filter_templates"
+      {...overrides}
+    />
+  )
+}
+
+describe("AdvancedFilterBuilder", () => {
+  it("renders the filter builder heading", () => {
+    renderBuilder()
+    expect(screen.getByText("[FILTER_BUILDER]")).toBeInTheDocument()
+  })
+
+  it("renders AND and OR logic buttons", () => {
+    renderBuilder()
+    expect(screen.getByRole("button", { name: "AND" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "OR" })).toBeInTheDocument()
+  })
+
+  it("defaults to AND logic", () => {
+    renderBuilder()
+    const andBtn = screen.getByRole("button", { name: "AND" })
+    expect(andBtn).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("switches to OR logic when OR is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByRole("button", { name: "OR" }))
+    expect(screen.getByRole("button", { name: "OR" })).toHaveAttribute("aria-pressed", "true")
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ logic: "OR" }))
+  })
+
+  it("renders one condition row by default", () => {
+    renderBuilder()
+    expect(screen.getAllByTestId("filter-condition")).toHaveLength(1)
+  })
+
+  it("adds a condition when ADD_CONDITION is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByText("+ ADD_CONDITION"))
+    expect(screen.getAllByTestId("filter-condition")).toHaveLength(2)
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  it("removes a condition when remove button is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByText("+ ADD_CONDITION"))
+    expect(screen.getAllByTestId("filter-condition")).toHaveLength(2)
+    fireEvent.click(screen.getAllByLabelText("Remove condition")[0])
+    expect(screen.getAllByTestId("filter-condition")).toHaveLength(1)
+  })
+
+  it("updates field select and calls onChange", () => {
+    renderBuilder()
+    const fieldSelect = screen.getAllByLabelText("Filter field")[0]
+    fireEvent.change(fieldSelect, { target: { value: "eventType" } })
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ field: "eventType" }),
+        ]),
+      })
+    )
+  })
+
+  it("updates operator select and calls onChange", () => {
+    renderBuilder()
+    const opSelect = screen.getAllByLabelText("Filter operator")[0]
+    fireEvent.change(opSelect, { target: { value: "contains" } })
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ operator: "contains" }),
+        ]),
+      })
+    )
+  })
+
+  it("updates value input and calls onChange", () => {
+    renderBuilder()
+    const valueInput = screen.getAllByLabelText("Filter value")[0]
+    fireEvent.change(valueInput, { target: { value: "swap" } })
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ value: "swap" }),
+        ]),
+      })
+    )
+  })
+
+  it("shows filter preview", () => {
+    renderBuilder()
+    expect(screen.getByTestId("filter-preview")).toBeInTheDocument()
+  })
+
+  it("preview updates when value changes", () => {
+    renderBuilder()
+    const valueInput = screen.getAllByLabelText("Filter value")[0]
+    fireEvent.change(valueInput, { target: { value: "myvalue" } })
+    expect(screen.getByTestId("filter-preview").textContent).toContain("myvalue")
+  })
+
+  it("calls onApply when APPLY is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByRole("button", { name: "APPLY" }))
+    expect(mockOnApply).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows save input when SAVE button is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByRole("button", { name: "SAVE" }))
+    expect(screen.getByLabelText("Template name")).toBeInTheDocument()
+  })
+
+  it("saves a template and shows it in the list", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByRole("button", { name: "SAVE" }))
+    const nameInput = screen.getByLabelText("Template name")
+    fireEvent.change(nameInput, { target: { value: "My Filter" } })
+    // Click the second SAVE button (inside the save form)
+    const saveBtns = screen.getAllByRole("button", { name: "SAVE" })
+    fireEvent.click(saveBtns[saveBtns.length - 1])
+    expect(screen.getByText("My Filter")).toBeInTheDocument()
+  })
+
+  it("loads a saved template when clicked", () => {
+    // Pre-populate localStorage
+    const template = {
+      name: "Preset",
+      group: { logic: "OR", conditions: [{ id: "x", field: "ledger", operator: "gt", value: "100" }] },
+    }
+    localStorage.setItem("test_filter_templates", JSON.stringify([template]))
+    renderBuilder()
+    fireEvent.click(screen.getByText("Preset"))
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({ logic: "OR" })
+    )
+  })
+
+  it("deletes a saved template", () => {
+    const template = { name: "ToDelete", group: { logic: "AND", conditions: [] } }
+    localStorage.setItem("test_filter_templates", JSON.stringify([template]))
+    renderBuilder()
+    expect(screen.getByText("ToDelete")).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText("Delete template ToDelete"))
+    expect(screen.queryByText("ToDelete")).not.toBeInTheDocument()
+  })
+})

--- a/soroscan-frontend/__tests__/org-logo-upload.test.tsx
+++ b/soroscan-frontend/__tests__/org-logo-upload.test.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { OrgLogoUpload } from "@/components/ui/OrgLogoUpload"
+
+const mockOnSave = jest.fn()
+
+class MockImage {
+  naturalWidth = 200
+  naturalHeight = 200
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+  private _src = ""
+  get src() { return this._src }
+  set src(v: string) { this._src = v; setTimeout(() => this.onload?.(), 0) }
+}
+
+const mockDrawImage = jest.fn()
+const mockToDataURL = jest.fn(() => "data:image/png;base64,CROPPED")
+
+beforeAll(() => {
+  // @ts-expect-error mock
+  global.Image = MockImage
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({ drawImage: mockDrawImage })) as unknown as typeof HTMLCanvasElement.prototype.getContext
+  HTMLCanvasElement.prototype.toDataURL = mockToDataURL
+})
+
+beforeEach(() => { mockOnSave.mockClear(); mockDrawImage.mockClear(); mockToDataURL.mockClear() })
+
+function makeFile(name = "logo.png", type = "image/png", size = 100) {
+  return new File([new Uint8Array(size)], name, { type })
+}
+
+function mockFileReader(result: string) {
+  const fr = { readAsDataURL: jest.fn(), onload: null as unknown, result }
+  jest.spyOn(global, "FileReader").mockImplementation(() => fr as unknown as FileReader)
+  return fr
+}
+
+describe("OrgLogoUpload", () => {
+  it("renders the upload heading", () => {
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    expect(screen.getByText("[ORG_LOGO]")).toBeInTheDocument()
+  })
+
+  it("renders UPLOAD_LOGO button by default", () => {
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    expect(screen.getByRole("button", { name: "UPLOAD_LOGO" })).toBeInTheDocument()
+  })
+
+  it("renders CHANGE_LOGO when currentLogoUrl is provided", () => {
+    render(<OrgLogoUpload onSave={mockOnSave} currentLogoUrl="https://example.com/logo.png" />)
+    expect(screen.getByRole("button", { name: "CHANGE_LOGO" })).toBeInTheDocument()
+  })
+
+  it("shows current logo preview when currentLogoUrl is provided", () => {
+    render(<OrgLogoUpload onSave={mockOnSave} currentLogoUrl="https://example.com/logo.png" />)
+    const img = screen.getByTestId("logo-preview") as HTMLImageElement
+    expect(img.src).toContain("example.com/logo.png")
+  })
+
+  it("shows error for unsupported file type", async () => {
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    fireEvent.change(screen.getByTestId("logo-file-input"), {
+      target: { files: [makeFile("doc.pdf", "application/pdf")] },
+    })
+    await waitFor(() => expect(screen.getByTestId("logo-error").textContent).toMatch(/Unsupported file type/))
+  })
+
+  it("shows error when file exceeds max size", async () => {
+    render(<OrgLogoUpload onSave={mockOnSave} maxSizeBytes={50} />)
+    fireEvent.change(screen.getByTestId("logo-file-input"), {
+      target: { files: [makeFile("big.png", "image/png", 200)] },
+    })
+    await waitFor(() => expect(screen.getByTestId("logo-error").textContent).toMatch(/too large/))
+  })
+
+  it("shows crop tool after valid file is selected", async () => {
+    const fr = mockFileReader("data:image/png;base64,FAKE")
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    fireEvent.change(screen.getByTestId("logo-file-input"), { target: { files: [makeFile()] } })
+    ;(fr.onload as unknown as (e: unknown) => void)?.({ target: { result: fr.result } })
+    await waitFor(() => expect(screen.getByTestId("crop-tool")).toBeInTheDocument())
+    jest.restoreAllMocks()
+  })
+
+  it("removes logo when REMOVE is clicked", () => {
+    render(<OrgLogoUpload onSave={mockOnSave} currentLogoUrl="https://example.com/logo.png" />)
+    fireEvent.click(screen.getByLabelText("Remove logo"))
+    expect(screen.queryByTestId("logo-preview")).not.toBeInTheDocument()
+  })
+
+  it("shows file type hint text", () => {
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    expect(screen.getByText(/PNG, JPEG, GIF, WEBP/)).toBeInTheDocument()
+  })
+
+  it("crop tool has decrease and increase size buttons", async () => {
+    const fr = mockFileReader("data:image/png;base64,FAKE")
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    fireEvent.change(screen.getByTestId("logo-file-input"), { target: { files: [makeFile()] } })
+    ;(fr.onload as unknown as (e: unknown) => void)?.({ target: { result: fr.result } })
+    await waitFor(() => screen.getByTestId("crop-tool"))
+    expect(screen.getByLabelText("Decrease crop size")).toBeInTheDocument()
+    expect(screen.getByLabelText("Increase crop size")).toBeInTheDocument()
+    jest.restoreAllMocks()
+  })
+
+  it("crop tool CANCEL returns to upload view", async () => {
+    const fr = mockFileReader("data:image/png;base64,FAKE")
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    fireEvent.change(screen.getByTestId("logo-file-input"), { target: { files: [makeFile()] } })
+    ;(fr.onload as unknown as (e: unknown) => void)?.({ target: { result: fr.result } })
+    await waitFor(() => screen.getByTestId("crop-tool"))
+    fireEvent.click(screen.getByRole("button", { name: "CANCEL" }))
+    expect(screen.queryByTestId("crop-tool")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "UPLOAD_LOGO" })).toBeInTheDocument()
+    jest.restoreAllMocks()
+  })
+
+  it("crop tool CONFIRM_CROP calls onSave with data URL", async () => {
+    const fr = mockFileReader("data:image/png;base64,FAKE")
+    render(<OrgLogoUpload onSave={mockOnSave} />)
+    fireEvent.change(screen.getByTestId("logo-file-input"), { target: { files: [makeFile()] } })
+    ;(fr.onload as unknown as (e: unknown) => void)?.({ target: { result: fr.result } })
+    await waitFor(() => screen.getByTestId("crop-tool"))
+    fireEvent.click(screen.getByRole("button", { name: "CONFIRM_CROP" }))
+    await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith("data:image/png;base64,CROPPED"))
+    jest.restoreAllMocks()
+  })
+})

--- a/soroscan-frontend/__tests__/time-range-picker.test.tsx
+++ b/soroscan-frontend/__tests__/time-range-picker.test.tsx
@@ -1,0 +1,93 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TimeRangePicker } from "@/components/ui/TimeRangePicker"
+
+const mockOnChange = jest.fn()
+
+beforeEach(() => mockOnChange.mockClear())
+
+describe("TimeRangePicker", () => {
+  it("renders preset buttons", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    expect(screen.getByText("Last 1h")).toBeInTheDocument()
+    expect(screen.getByText("Last 24h")).toBeInTheDocument()
+    expect(screen.getByText("Last 7d")).toBeInTheDocument()
+    expect(screen.getByText("Last 30d")).toBeInTheDocument()
+  })
+
+  it("renders FROM and TO datetime inputs", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    expect(screen.getByLabelText("From date and time")).toBeInTheDocument()
+    expect(screen.getByLabelText("To date and time")).toBeInTheDocument()
+  })
+
+  it("renders timezone selector with UTC default", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    const tzSelect = screen.getByLabelText("Timezone")
+    expect(tzSelect).toBeInTheDocument()
+    expect((tzSelect as HTMLSelectElement).value).toBe("UTC")
+  })
+
+  it("calls onChange when a preset is clicked", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    fireEvent.click(screen.getByText("Last 1h"))
+    expect(mockOnChange).toHaveBeenCalledTimes(1)
+    const arg = mockOnChange.mock.calls[0][0]
+    expect(arg).toHaveProperty("from")
+    expect(arg).toHaveProperty("to")
+    expect(arg.timezone).toBe("UTC")
+    // from should be ~1h before to
+    const diffMs = arg.to.getTime() - arg.from.getTime()
+    expect(diffMs).toBeCloseTo(60 * 60 * 1000, -3)
+  })
+
+  it("calls onChange when timezone changes", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    const tzSelect = screen.getByLabelText("Timezone")
+    fireEvent.change(tzSelect, { target: { value: "Europe/London" } })
+    expect(mockOnChange).toHaveBeenCalledTimes(1)
+    expect(mockOnChange.mock.calls[0][0].timezone).toBe("Europe/London")
+  })
+
+  it("highlights active preset after clicking", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    const btn = screen.getByText("Last 7d")
+    fireEvent.click(btn)
+    expect(btn.className).toMatch(/bg-terminal-green/)
+  })
+
+  it("shows UTC display below FROM input after preset click", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    fireEvent.click(screen.getByText("Last 1h"))
+    // UTC display should contain "UTC"
+    const utcLabels = screen.getAllByText(/UTC/)
+    expect(utcLabels.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("calls onChange when FROM input changes", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    const fromInput = screen.getByLabelText("From date and time")
+    fireEvent.change(fromInput, { target: { value: "2025-01-01T00:00" } })
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  it("calls onChange when TO input changes", () => {
+    render(<TimeRangePicker onChange={mockOnChange} />)
+    const toInput = screen.getByLabelText("To date and time")
+    fireEvent.change(toInput, { target: { value: "2025-01-02T00:00" } })
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  it("accepts a value prop and reflects it", () => {
+    const from = new Date("2025-06-01T10:00:00Z")
+    const to   = new Date("2025-06-01T12:00:00Z")
+    render(
+      <TimeRangePicker
+        value={{ from, to, timezone: "UTC" }}
+        onChange={mockOnChange}
+      />
+    )
+    const fromInput = screen.getByLabelText("From date and time") as HTMLInputElement
+    expect(fromInput.value).toBe("2025-06-01T10:00")
+  })
+})

--- a/soroscan-frontend/__tests__/webhook-components.test.tsx
+++ b/soroscan-frontend/__tests__/webhook-components.test.tsx
@@ -44,7 +44,6 @@ describe("WebhookTable", () => {
         onTest={mockTest}
       />
     )
-    // Each row has a URL link — text partially matches first webhook URL
     expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(MOCK_WEBHOOKS.length)
   })
 
@@ -59,7 +58,7 @@ describe("WebhookTable", () => {
     render(
       <WebhookTable webhooks={MOCK_WEBHOOKS} onDelete={mockDelete} onTest={mockTest} />
     )
-    expect(screen.getByText("FAILED")).toBeInTheDocument()
+    expect(screen.getAllByText("FAILED").length).toBeGreaterThanOrEqual(1)
   })
 
   it("shows empty state when no webhooks", () => {
@@ -77,7 +76,7 @@ describe("WebhookTable", () => {
         onTest={mockTest}
       />
     )
-    fireEvent.click(screen.getByTitle("Delete webhook"))
+    fireEvent.click(screen.getAllByTitle("Delete webhook")[0])
     expect(mockDelete).toHaveBeenCalledWith(MOCK_WEBHOOKS[0].id)
   })
 
@@ -89,7 +88,7 @@ describe("WebhookTable", () => {
         onTest={mockTest}
       />
     )
-    fireEvent.click(screen.getByTitle("Test webhook"))
+    fireEvent.click(screen.getAllByTitle("Test webhook")[0])
     expect(mockTest).toHaveBeenCalledWith(MOCK_WEBHOOKS[0].id)
   })
 
@@ -102,7 +101,69 @@ describe("WebhookTable", () => {
         testResult={{ id: MOCK_WEBHOOKS[0].id, ok: true, code: 200 }}
       />
     )
-    expect(screen.getByText(/TEST_OK/)).toBeInTheDocument()
+    expect(screen.getAllByText(/TEST_OK/).length).toBeGreaterThanOrEqual(1)
+  })
+
+  // ── Responsive / mobile ──────────────────────────────────────────────────
+
+  it("renders mobile card list container", () => {
+    render(
+      <WebhookTable webhooks={MOCK_WEBHOOKS} onDelete={mockDelete} onTest={mockTest} />
+    )
+    expect(screen.getByTestId("webhook-mobile-list")).toBeInTheDocument()
+  })
+
+  it("renders desktop table container", () => {
+    render(
+      <WebhookTable webhooks={MOCK_WEBHOOKS} onDelete={mockDelete} onTest={mockTest} />
+    )
+    expect(screen.getByTestId("webhook-desktop-table")).toBeInTheDocument()
+  })
+
+  it("renders one mobile card per webhook", () => {
+    render(
+      <WebhookTable webhooks={MOCK_WEBHOOKS} onDelete={mockDelete} onTest={mockTest} />
+    )
+    expect(screen.getAllByTestId("webhook-card")).toHaveLength(MOCK_WEBHOOKS.length)
+  })
+
+  it("mobile card shows expand/collapse button", () => {
+    render(
+      <WebhookTable
+        webhooks={[MOCK_WEBHOOKS[0]]}
+        onDelete={mockDelete}
+        onTest={mockTest}
+      />
+    )
+    expect(screen.getByLabelText("Expand details")).toBeInTheDocument()
+  })
+
+  it("mobile card expands to show details on toggle", () => {
+    render(
+      <WebhookTable
+        webhooks={[MOCK_WEBHOOKS[0]]}
+        onDelete={mockDelete}
+        onTest={mockTest}
+      />
+    )
+    const expandBtn = screen.getByLabelText("Expand details")
+    fireEvent.click(expandBtn)
+    expect(screen.getByLabelText("Collapse details")).toBeInTheDocument()
+    // After expand, action buttons appear in the card
+    expect(screen.getAllByTitle("Delete webhook").length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("mobile action buttons have touch-friendly size (min-h-[44px])", () => {
+    render(
+      <WebhookTable
+        webhooks={[MOCK_WEBHOOKS[0]]}
+        onDelete={mockDelete}
+        onTest={mockTest}
+      />
+    )
+    fireEvent.click(screen.getByLabelText("Expand details"))
+    const deleteBtn = screen.getAllByTitle("Delete webhook")[0]
+    expect(deleteBtn.className).toMatch(/min-h-\[44px\]/)
   })
 })
 
@@ -184,7 +245,6 @@ describe("DeliveryLog", () => {
     render(<DeliveryLog logs={logs} />)
     const btn = screen.getByRole("button", { name: "2xx" })
     fireEvent.click(btn)
-    // All visible "OK" texts should be present, no ERROR texts visible
     const statusCells = screen.queryAllByText(/^[45]\d\d$/)
     expect(statusCells).toHaveLength(0)
   })

--- a/soroscan-frontend/app/webhooks/components/WebhookTable.tsx
+++ b/soroscan-frontend/app/webhooks/components/WebhookTable.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import Link from "next/link"
-import { Trash2, FlaskConical } from "lucide-react"
+import { Trash2, FlaskConical, ChevronDown, ChevronUp } from "lucide-react"
 import {
   Table, TableHeader, TableBody, TableRow, TableHead, TableCell,
   SortDirectionIndicator,
@@ -49,6 +49,130 @@ function SuccessBar({ rate }: { rate: number }) {
   )
 }
 
+// ── Mobile card for a single webhook ──────────────────────────────────────
+
+function WebhookCard({
+  wh,
+  onDelete,
+  onTest,
+  isTesting,
+  result,
+}: {
+  wh: Webhook
+  onDelete: (id: string) => void
+  onTest: (id: string) => void
+  isTesting: boolean
+  result: { ok: boolean; code: number } | null
+}) {
+  const [expanded, setExpanded] = React.useState(false)
+
+  return (
+    <div className="border border-terminal-green/20 font-terminal-mono" data-testid="webhook-card">
+      {/* Primary row — always visible */}
+      <div className="flex items-center gap-3 p-3">
+        <StatusBadge status={wh.status} />
+
+        <Link
+          href={`/webhooks/${wh.id}`}
+          className="flex-1 text-terminal-cyan hover:text-terminal-green transition-colors text-[11px] truncate"
+        >
+          {wh.url}
+        </Link>
+
+        {/* Touch-friendly expand toggle */}
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse details" : "Expand details"}
+          className="min-w-[44px] min-h-[44px] flex items-center justify-center text-terminal-gray hover:text-terminal-green transition-colors"
+        >
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
+      </div>
+
+      {/* Collapsible details */}
+      {expanded && (
+        <div className="border-t border-terminal-green/10 px-3 pb-3 space-y-2 text-[10px]">
+          {/* Event types */}
+          <div className="flex flex-wrap gap-1 pt-2">
+            {wh.eventTypes.slice(0, 5).map((t) => (
+              <span key={t} className="border border-terminal-green/30 px-1 text-terminal-gray">
+                {t === "ALL" ? "ALL_EVENTS" : t}
+              </span>
+            ))}
+            {wh.eventTypes.length > 5 && (
+              <span className="text-terminal-gray/60">+{wh.eventTypes.length - 5}</span>
+            )}
+          </div>
+
+          {/* Success rate */}
+          <div className="flex items-center gap-2">
+            <span className="text-terminal-gray w-20">SUCCESS</span>
+            <SuccessBar rate={wh.successRate} />
+          </div>
+
+          {/* Last delivery */}
+          <div className="flex items-center gap-2">
+            <span className="text-terminal-gray w-20">LAST_DELIVERY</span>
+            <span className="text-terminal-gray">
+              {wh.lastDelivery
+                ? new Date(wh.lastDelivery).toLocaleString("en-GB", { dateStyle: "short", timeStyle: "short" })
+                : "—"}
+            </span>
+            {wh.lastStatusCode && (
+              <span className={`text-[9px] ${wh.lastStatusCode < 300 ? "text-terminal-green" : "text-terminal-danger"}`}>
+                HTTP {wh.lastStatusCode}
+              </span>
+            )}
+          </div>
+
+          {/* Contract filter */}
+          {wh.contractFilter && (
+            <div className="flex items-center gap-2">
+              <span className="text-terminal-gray w-20">CONTRACT</span>
+              <span className="text-terminal-gray/80">{wh.contractFilter}</span>
+            </div>
+          )}
+
+          {/* Test result */}
+          {result && (
+            <div className={`text-[9px] ${result.ok ? "text-terminal-green" : "text-terminal-danger"}`}>
+              {result.ok ? `✓ TEST_OK (${result.code})` : `✗ TEST_FAILED (${result.code})`}
+            </div>
+          )}
+
+          {/* Actions — touch-friendly (min 44px) */}
+          <div className="flex gap-2 pt-1">
+            <Link href={`/webhooks/${wh.id}`} className="flex-1">
+              <Button variant="secondary" size="sm" className="w-full text-[9px] min-h-[44px]">
+                DETAIL
+              </Button>
+            </Link>
+            <button
+              onClick={() => onTest(wh.id)}
+              disabled={isTesting}
+              title="Test webhook"
+              className="min-w-[44px] min-h-[44px] flex items-center justify-center border border-terminal-cyan/40 text-terminal-cyan hover:border-terminal-cyan hover:bg-terminal-cyan/10 transition-colors disabled:opacity-50"
+            >
+              <FlaskConical size={14} />
+            </button>
+            <button
+              onClick={() => onDelete(wh.id)}
+              title="Delete webhook"
+              className="min-w-[44px] min-h-[44px] flex items-center justify-center border border-terminal-danger/40 text-terminal-danger hover:border-terminal-danger hover:bg-terminal-danger/10 transition-colors"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
 export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult }: WebhookTableProps) {
   const [sortField, setSortField] = React.useState<SortField>("lastDelivery")
   const [sortDir, setSortDir] = React.useState<SortDir>("desc")
@@ -80,140 +204,146 @@ export function WebhookTable({ webhooks, onDelete, onTest, testingId, testResult
   }
 
   return (
-    <div className="overflow-x-auto">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead
-              className="cursor-pointer select-none hover:text-terminal-green transition-colors"
-              onClick={() => toggleSort("status")}
-            >
-              <span className="inline-flex items-center gap-1">
-                STATUS
-                <SortDirectionIndicator active={sortField === "status"} direction={sortDir} />
-              </span>
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none hover:text-terminal-green transition-colors"
-              onClick={() => toggleSort("url")}
-            >
-              <span className="inline-flex items-center gap-1">
-                ENDPOINT_URL
-                <SortDirectionIndicator active={sortField === "url"} direction={sortDir} />
-              </span>
-            </TableHead>
-            <TableHead className="hidden md:table-cell">EVENT_TYPES</TableHead>
-            <TableHead
-              className="cursor-pointer select-none hover:text-terminal-green transition-colors"
-              onClick={() => toggleSort("successRate")}
-            >
-              <span className="inline-flex items-center gap-1">
-                SUCCESS
-                <SortDirectionIndicator active={sortField === "successRate"} direction={sortDir} />
-              </span>
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none hover:text-terminal-green transition-colors"
-              onClick={() => toggleSort("lastDelivery")}
-            >
-              <span className="inline-flex items-center gap-1">
-                LAST_DELIVERY
-                <SortDirectionIndicator active={sortField === "lastDelivery"} direction={sortDir} />
-              </span>
-            </TableHead>
-            <TableHead>ACTIONS</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sorted.map((wh) => {
-            const isTesting = testingId === wh.id
-            const result = testResult?.id === wh.id ? testResult : null
-            return (
-              <TableRow key={wh.id}>
-                {/* Status */}
-                <TableCell><StatusBadge status={wh.status} /></TableCell>
+    <>
+      {/* Mobile: stacked cards (hidden on md+) */}
+      <div className="md:hidden space-y-2" data-testid="webhook-mobile-list">
+        {sorted.map((wh) => (
+          <WebhookCard
+            key={wh.id}
+            wh={wh}
+            onDelete={onDelete}
+            onTest={onTest}
+            isTesting={testingId === wh.id}
+            result={testResult?.id === wh.id ? testResult : null}
+          />
+        ))}
+      </div>
 
-                {/* URL */}
-                <TableCell>
-                  <div className="max-w-[180px] sm:max-w-[280px] lg:max-w-none">
-                    <Link
-                      href={`/webhooks/${wh.id}`}
-                      className="text-terminal-cyan hover:text-terminal-green transition-colors text-[11px] block truncate font-terminal-mono"
-                    >
-                      {wh.url}
-                    </Link>
-                    {wh.contractFilter && (
-                      <div className="text-[9px] text-terminal-gray/60 mt-0.5">
-                        CONTRACT: {wh.contractFilter}
-                      </div>
-                    )}
-                    {result && (
-                      <div className={`text-[9px] mt-1 ${result.ok ? "text-terminal-green" : "text-terminal-danger"}`}>
-                        {result.ok ? `✓ TEST_OK (${result.code})` : `✗ TEST_FAILED (${result.code})`}
-                      </div>
-                    )}
-                  </div>
-                </TableCell>
-
-                {/* Event types */}
-                <TableCell className="hidden md:table-cell">
-                  <div className="flex flex-wrap gap-1 max-w-[200px]">
-                    {wh.eventTypes.slice(0, 3).map((t) => (
-                      <span key={t} className="text-[9px] border border-terminal-green/30 px-1 text-terminal-gray">
-                        {t === "ALL" ? "ALL_EVENTS" : t}
-                      </span>
-                    ))}
-                    {wh.eventTypes.length > 3 && (
-                      <span className="text-[9px] text-terminal-gray/60">+{wh.eventTypes.length - 3}</span>
-                    )}
-                  </div>
-                </TableCell>
-
-                {/* Success rate */}
-                <TableCell><SuccessBar rate={wh.successRate} /></TableCell>
-
-                {/* Last delivery */}
-                <TableCell className="text-[11px] whitespace-nowrap text-terminal-gray">
-                  {wh.lastDelivery
-                    ? new Date(wh.lastDelivery).toLocaleString("en-GB", { dateStyle: "short", timeStyle: "short" })
-                    : "—"}
-                  {wh.lastStatusCode && (
-                    <div className={`text-[9px] mt-0.5 ${wh.lastStatusCode < 300 ? "text-terminal-green" : "text-terminal-danger"}`}>
-                      HTTP {wh.lastStatusCode}
+      {/* Desktop: table (hidden below md) */}
+      <div className="hidden md:block overflow-x-auto" data-testid="webhook-desktop-table">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead
+                className="cursor-pointer select-none hover:text-terminal-green transition-colors"
+                onClick={() => toggleSort("status")}
+              >
+                <span className="inline-flex items-center gap-1">
+                  STATUS
+                  <SortDirectionIndicator active={sortField === "status"} direction={sortDir} />
+                </span>
+              </TableHead>
+              <TableHead
+                className="cursor-pointer select-none hover:text-terminal-green transition-colors"
+                onClick={() => toggleSort("url")}
+              >
+                <span className="inline-flex items-center gap-1">
+                  ENDPOINT_URL
+                  <SortDirectionIndicator active={sortField === "url"} direction={sortDir} />
+                </span>
+              </TableHead>
+              <TableHead>EVENT_TYPES</TableHead>
+              <TableHead
+                className="cursor-pointer select-none hover:text-terminal-green transition-colors"
+                onClick={() => toggleSort("successRate")}
+              >
+                <span className="inline-flex items-center gap-1">
+                  SUCCESS
+                  <SortDirectionIndicator active={sortField === "successRate"} direction={sortDir} />
+                </span>
+              </TableHead>
+              <TableHead
+                className="cursor-pointer select-none hover:text-terminal-green transition-colors"
+                onClick={() => toggleSort("lastDelivery")}
+              >
+                <span className="inline-flex items-center gap-1">
+                  LAST_DELIVERY
+                  <SortDirectionIndicator active={sortField === "lastDelivery"} direction={sortDir} />
+                </span>
+              </TableHead>
+              <TableHead>ACTIONS</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sorted.map((wh) => {
+              const isTesting = testingId === wh.id
+              const result = testResult?.id === wh.id ? testResult : null
+              return (
+                <TableRow key={wh.id}>
+                  <TableCell><StatusBadge status={wh.status} /></TableCell>
+                  <TableCell>
+                    <div className="max-w-[280px] lg:max-w-none">
+                      <Link
+                        href={`/webhooks/${wh.id}`}
+                        className="text-terminal-cyan hover:text-terminal-green transition-colors text-[11px] block truncate font-terminal-mono"
+                      >
+                        {wh.url}
+                      </Link>
+                      {wh.contractFilter && (
+                        <div className="text-[9px] text-terminal-gray/60 mt-0.5">
+                          CONTRACT: {wh.contractFilter}
+                        </div>
+                      )}
+                      {result && (
+                        <div className={`text-[9px] mt-1 ${result.ok ? "text-terminal-green" : "text-terminal-danger"}`}>
+                          {result.ok ? `✓ TEST_OK (${result.code})` : `✗ TEST_FAILED (${result.code})`}
+                        </div>
+                      )}
                     </div>
-                  )}
-                </TableCell>
-
-                {/* Actions */}
-                <TableCell>
-                  <div className="flex items-center gap-1.5">
-                    <Link href={`/webhooks/${wh.id}`}>
-                      <Button variant="secondary" size="sm" className="text-[9px] h-7 px-2 hidden sm:inline-flex">
-                        DETAIL
-                      </Button>
-                    </Link>
-                    <button
-                      onClick={() => onTest(wh.id)}
-                      disabled={isTesting}
-                      title="Test webhook"
-                      className="h-7 w-7 flex items-center justify-center border border-terminal-cyan/40 text-terminal-cyan hover:border-terminal-cyan hover:bg-terminal-cyan/10 transition-colors disabled:opacity-50"
-                    >
-                      <FlaskConical size={12} />
-                    </button>
-                    <button
-                      onClick={() => onDelete(wh.id)}
-                      title="Delete webhook"
-                      className="h-7 w-7 flex items-center justify-center border border-terminal-danger/40 text-terminal-danger hover:border-terminal-danger hover:bg-terminal-danger/10 transition-colors"
-                    >
-                      <Trash2 size={12} />
-                    </button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1 max-w-[200px]">
+                      {wh.eventTypes.slice(0, 3).map((t) => (
+                        <span key={t} className="text-[9px] border border-terminal-green/30 px-1 text-terminal-gray">
+                          {t === "ALL" ? "ALL_EVENTS" : t}
+                        </span>
+                      ))}
+                      {wh.eventTypes.length > 3 && (
+                        <span className="text-[9px] text-terminal-gray/60">+{wh.eventTypes.length - 3}</span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell><SuccessBar rate={wh.successRate} /></TableCell>
+                  <TableCell className="text-[11px] whitespace-nowrap text-terminal-gray">
+                    {wh.lastDelivery
+                      ? new Date(wh.lastDelivery).toLocaleString("en-GB", { dateStyle: "short", timeStyle: "short" })
+                      : "—"}
+                    {wh.lastStatusCode && (
+                      <div className={`text-[9px] mt-0.5 ${wh.lastStatusCode < 300 ? "text-terminal-green" : "text-terminal-danger"}`}>
+                        HTTP {wh.lastStatusCode}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1.5">
+                      <Link href={`/webhooks/${wh.id}`}>
+                        <Button variant="secondary" size="sm" className="text-[9px] h-7 px-2">
+                          DETAIL
+                        </Button>
+                      </Link>
+                      <button
+                        onClick={() => onTest(wh.id)}
+                        disabled={isTesting}
+                        title="Test webhook"
+                        className="h-7 w-7 flex items-center justify-center border border-terminal-cyan/40 text-terminal-cyan hover:border-terminal-cyan hover:bg-terminal-cyan/10 transition-colors disabled:opacity-50"
+                      >
+                        <FlaskConical size={12} />
+                      </button>
+                      <button
+                        onClick={() => onDelete(wh.id)}
+                        title="Delete webhook"
+                        className="h-7 w-7 flex items-center justify-center border border-terminal-danger/40 text-terminal-danger hover:border-terminal-danger hover:bg-terminal-danger/10 transition-colors"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   )
 }

--- a/soroscan-frontend/components/ui/AdvancedFilterBuilder.tsx
+++ b/soroscan-frontend/components/ui/AdvancedFilterBuilder.tsx
@@ -1,0 +1,296 @@
+"use client"
+
+import * as React from "react"
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type LogicOp = "AND" | "OR"
+export type Operator = "eq" | "neq" | "contains" | "gt" | "lt" | "gte" | "lte"
+
+export interface FilterCondition {
+  id: string
+  field: string
+  operator: Operator
+  value: string
+}
+
+export interface FilterGroup {
+  logic: LogicOp
+  conditions: FilterCondition[]
+}
+
+export interface SavedTemplate {
+  name: string
+  group: FilterGroup
+}
+
+interface AdvancedFilterBuilderProps {
+  fields: string[]
+  value?: FilterGroup
+  onChange: (group: FilterGroup) => void
+  onApply: (group: FilterGroup) => void
+  storageKey?: string
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const OPERATORS: { value: Operator; label: string }[] = [
+  { value: "eq",       label: "=" },
+  { value: "neq",      label: "≠" },
+  { value: "contains", label: "contains" },
+  { value: "gt",       label: ">" },
+  { value: "lt",       label: "<" },
+  { value: "gte",      label: ">=" },
+  { value: "lte",      label: "<=" },
+]
+
+function uid() {
+  return Math.random().toString(36).slice(2, 9)
+}
+
+function emptyCondition(field: string): FilterCondition {
+  return { id: uid(), field, operator: "eq", value: "" }
+}
+
+function emptyGroup(field: string): FilterGroup {
+  return { logic: "AND", conditions: [emptyCondition(field)] }
+}
+
+function buildPreview(group: FilterGroup): string {
+  if (group.conditions.length === 0) return "(empty)"
+  return group.conditions
+    .map((c) => `${c.field} ${c.operator} "${c.value}"`)
+    .join(` ${group.logic} `)
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function AdvancedFilterBuilder({
+  fields,
+  value,
+  onChange,
+  onApply,
+  storageKey = "soroscan_filter_templates",
+}: AdvancedFilterBuilderProps) {
+  const defaultField = fields[0] ?? "field"
+  const [group, setGroup] = React.useState<FilterGroup>(
+    value ?? emptyGroup(defaultField)
+  )
+  const [templates, setTemplates] = React.useState<SavedTemplate[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(storageKey) ?? "[]")
+    } catch {
+      return []
+    }
+  })
+  const [saveName, setSaveName] = React.useState("")
+  const [showSave, setShowSave] = React.useState(false)
+
+  // Sync external value
+  React.useEffect(() => {
+    if (value) setGroup(value)
+  }, [value])
+
+  const update = (next: FilterGroup) => {
+    setGroup(next)
+    onChange(next)
+  }
+
+  const setLogic = (logic: LogicOp) => update({ ...group, logic })
+
+  const addCondition = () =>
+    update({ ...group, conditions: [...group.conditions, emptyCondition(defaultField)] })
+
+  const removeCondition = (id: string) =>
+    update({ ...group, conditions: group.conditions.filter((c) => c.id !== id) })
+
+  const updateCondition = (id: string, patch: Partial<FilterCondition>) =>
+    update({
+      ...group,
+      conditions: group.conditions.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+    })
+
+  const saveTemplate = () => {
+    if (!saveName.trim()) return
+    const next: SavedTemplate[] = [...templates, { name: saveName.trim(), group }]
+    setTemplates(next)
+    try { localStorage.setItem(storageKey, JSON.stringify(next)) } catch { /* noop */ }
+    setSaveName("")
+    setShowSave(false)
+  }
+
+  const loadTemplate = (t: SavedTemplate) => update(t.group)
+
+  const deleteTemplate = (name: string) => {
+    const next = templates.filter((t) => t.name !== name)
+    setTemplates(next)
+    try { localStorage.setItem(storageKey, JSON.stringify(next)) } catch { /* noop */ }
+  }
+
+  return (
+    <div className="border border-terminal-green/30 bg-terminal-black font-terminal-mono text-[11px] space-y-0" role="group" aria-label="Advanced filter builder">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-terminal-green/20">
+        <span className="text-terminal-green text-[10px] tracking-widest">[FILTER_BUILDER]</span>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => setShowSave((s) => !s)}
+            className="text-[9px] px-2 py-0.5 border border-terminal-cyan/40 text-terminal-cyan hover:border-terminal-cyan transition-colors"
+          >
+            SAVE
+          </button>
+          <button
+            type="button"
+            onClick={() => onApply(group)}
+            className="text-[9px] px-2 py-0.5 border border-terminal-green/60 text-terminal-green hover:bg-terminal-green/10 transition-colors"
+          >
+            APPLY
+          </button>
+        </div>
+      </div>
+
+      {/* Logic toggle */}
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-terminal-green/10">
+        <span className="text-terminal-gray">MATCH</span>
+        {(["AND", "OR"] as LogicOp[]).map((op) => (
+          <button
+            key={op}
+            type="button"
+            onClick={() => setLogic(op)}
+            aria-pressed={group.logic === op}
+            className={`px-3 py-0.5 border text-[10px] transition-colors ${
+              group.logic === op
+                ? "border-terminal-green bg-terminal-green/20 text-terminal-green"
+                : "border-terminal-green/30 text-terminal-gray hover:border-terminal-green"
+            }`}
+          >
+            {op}
+          </button>
+        ))}
+        <span className="text-terminal-gray">conditions</span>
+      </div>
+
+      {/* Conditions */}
+      <div className="px-4 py-2 space-y-2">
+        {group.conditions.map((cond, idx) => (
+          <div key={cond.id} className="flex flex-wrap items-center gap-2" data-testid="filter-condition">
+            {idx > 0 && (
+              <span className="text-[9px] text-terminal-cyan w-6 text-center">{group.logic}</span>
+            )}
+            {idx === 0 && <span className="text-[9px] text-terminal-gray w-6 text-center">IF</span>}
+
+            {/* Field */}
+            <select
+              value={cond.field}
+              onChange={(e) => updateCondition(cond.id, { field: e.target.value })}
+              aria-label="Filter field"
+              className="bg-transparent border border-terminal-green/30 text-terminal-green px-2 py-1 focus:outline-none focus:border-terminal-green"
+            >
+              {fields.map((f) => (
+                <option key={f} value={f} className="bg-[#0a0e27]">{f}</option>
+              ))}
+            </select>
+
+            {/* Operator */}
+            <select
+              value={cond.operator}
+              onChange={(e) => updateCondition(cond.id, { operator: e.target.value as Operator })}
+              aria-label="Filter operator"
+              className="bg-transparent border border-terminal-green/30 text-terminal-green px-2 py-1 focus:outline-none focus:border-terminal-green"
+            >
+              {OPERATORS.map((op) => (
+                <option key={op.value} value={op.value} className="bg-[#0a0e27]">{op.label}</option>
+              ))}
+            </select>
+
+            {/* Value */}
+            <input
+              type="text"
+              value={cond.value}
+              onChange={(e) => updateCondition(cond.id, { value: e.target.value })}
+              placeholder="value"
+              aria-label="Filter value"
+              className="bg-transparent border border-terminal-green/30 text-terminal-green px-2 py-1 focus:outline-none focus:border-terminal-green min-w-[100px]"
+            />
+
+            {/* Remove */}
+            {group.conditions.length > 1 && (
+              <button
+                type="button"
+                onClick={() => removeCondition(cond.id)}
+                aria-label="Remove condition"
+                className="text-terminal-danger hover:text-terminal-danger/80 px-1"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        ))}
+
+        <button
+          type="button"
+          onClick={addCondition}
+          className="text-[9px] text-terminal-cyan hover:text-terminal-green transition-colors mt-1"
+        >
+          + ADD_CONDITION
+        </button>
+      </div>
+
+      {/* Preview */}
+      <div className="px-4 py-2 border-t border-terminal-green/10 bg-terminal-green/5">
+        <span className="text-[9px] text-terminal-gray">PREVIEW: </span>
+        <span className="text-[9px] text-terminal-cyan break-all" data-testid="filter-preview">
+          {buildPreview(group)}
+        </span>
+      </div>
+
+      {/* Save template */}
+      {showSave && (
+        <div className="px-4 py-2 border-t border-terminal-green/20 flex gap-2">
+          <input
+            type="text"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            placeholder="Template name"
+            aria-label="Template name"
+            className="flex-1 bg-transparent border border-terminal-green/30 text-terminal-green px-2 py-1 focus:outline-none focus:border-terminal-green"
+          />
+          <button
+            type="button"
+            onClick={saveTemplate}
+            className="text-[9px] px-3 py-1 border border-terminal-green/60 text-terminal-green hover:bg-terminal-green/10 transition-colors"
+          >
+            SAVE
+          </button>
+        </div>
+      )}
+
+      {/* Saved templates */}
+      {templates.length > 0 && (
+        <div className="px-4 py-2 border-t border-terminal-green/20 space-y-1">
+          <div className="text-[9px] text-terminal-gray mb-1">SAVED_TEMPLATES</div>
+          {templates.map((t) => (
+            <div key={t.name} className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => loadTemplate(t)}
+                className="text-[10px] text-terminal-cyan hover:text-terminal-green transition-colors flex-1 text-left"
+              >
+                {t.name}
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteTemplate(t.name)}
+                aria-label={`Delete template ${t.name}`}
+                className="text-[9px] text-terminal-danger hover:text-terminal-danger/80"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/soroscan-frontend/components/ui/OrgLogoUpload.tsx
+++ b/soroscan-frontend/components/ui/OrgLogoUpload.tsx
@@ -1,0 +1,294 @@
+"use client"
+
+import * as React from "react"
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface OrgLogoUploadProps {
+  /** Called with the final cropped data-URL when the user confirms */
+  onSave: (dataUrl: string) => void
+  /** Current logo URL to display as initial preview */
+  currentLogoUrl?: string
+  /** Max file size in bytes (default 2 MB) */
+  maxSizeBytes?: number
+}
+
+const DEFAULT_MAX = 2 * 1024 * 1024 // 2 MB
+const ACCEPTED = ["image/png", "image/jpeg", "image/gif", "image/webp"]
+
+// ── Simple canvas crop helper ──────────────────────────────────────────────
+
+interface CropRect { x: number; y: number; size: number }
+
+function cropImage(src: string, crop: CropRect, outputSize = 256): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => {
+      const canvas = document.createElement("canvas")
+      canvas.width = outputSize
+      canvas.height = outputSize
+      const ctx = canvas.getContext("2d")
+      if (!ctx) return reject(new Error("canvas context unavailable"))
+      ctx.drawImage(img, crop.x, crop.y, crop.size, crop.size, 0, 0, outputSize, outputSize)
+      resolve(canvas.toDataURL("image/png"))
+    }
+    img.onerror = reject
+    img.src = src
+  })
+}
+
+// ── Crop UI ────────────────────────────────────────────────────────────────
+
+function CropTool({
+  src,
+  naturalWidth,
+  naturalHeight,
+  onConfirm,
+  onCancel,
+}: {
+  src: string
+  naturalWidth: number
+  naturalHeight: number
+  onConfirm: (crop: CropRect) => void
+  onCancel: () => void
+}) {
+  const minDim = Math.min(naturalWidth, naturalHeight)
+  const [crop, setCrop] = React.useState<CropRect>({
+    x: Math.floor((naturalWidth - minDim) / 2),
+    y: Math.floor((naturalHeight - minDim) / 2),
+    size: minDim,
+  })
+
+  // Display scale: show image at max 300px wide
+  const displayW = Math.min(300, naturalWidth)
+  const scale = displayW / naturalWidth
+  const displayH = naturalHeight * scale
+
+  const dCrop = {
+    x: crop.x * scale,
+    y: crop.y * scale,
+    size: crop.size * scale,
+  }
+
+  const handleSizeChange = (delta: number) => {
+    setCrop((c) => {
+      const newSize = Math.max(32, Math.min(minDim, c.size + delta))
+      return { ...c, size: newSize }
+    })
+  }
+
+  return (
+    <div className="space-y-3" data-testid="crop-tool">
+      <div className="text-[10px] text-terminal-gray">CROP_TOOL — drag to reposition, use buttons to resize</div>
+
+      {/* Image with crop overlay */}
+      <div
+        className="relative border border-terminal-green/30 inline-block"
+        style={{ width: displayW, height: displayH }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt="Crop preview" width={displayW} height={displayH} className="block" />
+        {/* Crop rectangle overlay */}
+        <div
+          className="absolute border-2 border-terminal-cyan pointer-events-none"
+          style={{
+            left: dCrop.x,
+            top: dCrop.y,
+            width: dCrop.size,
+            height: dCrop.size,
+          }}
+          data-testid="crop-rect"
+        />
+      </div>
+
+      {/* Size controls */}
+      <div className="flex items-center gap-2 text-[10px]">
+        <span className="text-terminal-gray">SIZE: {crop.size}px</span>
+        <button
+          type="button"
+          onClick={() => handleSizeChange(-16)}
+          className="px-2 py-0.5 border border-terminal-green/30 text-terminal-green hover:border-terminal-green transition-colors"
+          aria-label="Decrease crop size"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={() => handleSizeChange(16)}
+          className="px-2 py-0.5 border border-terminal-green/30 text-terminal-green hover:border-terminal-green transition-colors"
+          aria-label="Increase crop size"
+        >
+          +
+        </button>
+      </div>
+
+      {/* Confirm / cancel */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => onConfirm(crop)}
+          className="text-[10px] px-4 py-1.5 border border-terminal-green/60 text-terminal-green hover:bg-terminal-green/10 transition-colors"
+        >
+          CONFIRM_CROP
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-[10px] px-4 py-1.5 border border-terminal-gray/30 text-terminal-gray hover:border-terminal-gray transition-colors"
+        >
+          CANCEL
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export function OrgLogoUpload({
+  onSave,
+  currentLogoUrl,
+  maxSizeBytes = DEFAULT_MAX,
+}: OrgLogoUploadProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const [rawSrc, setRawSrc]         = React.useState<string | null>(null)
+  const [naturalSize, setNaturalSize] = React.useState<{ w: number; h: number } | null>(null)
+  const [preview, setPreview]       = React.useState<string | null>(currentLogoUrl ?? null)
+  const [error, setError]           = React.useState<string | null>(null)
+  const [cropping, setCropping]     = React.useState(false)
+  const [saving, setSaving]         = React.useState(false)
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setError(null)
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (!ACCEPTED.includes(file.type)) {
+      setError(`Unsupported file type. Accepted: PNG, JPEG, GIF, WEBP.`)
+      return
+    }
+    if (file.size > maxSizeBytes) {
+      setError(`File too large. Maximum size is ${(maxSizeBytes / 1024 / 1024).toFixed(1)} MB.`)
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const src = ev.target?.result as string
+      // Load image to get natural dimensions
+      const img = new Image()
+      img.onload = () => {
+        setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight })
+        setRawSrc(src)
+        setCropping(true)
+      }
+      img.src = src
+    }
+    reader.readAsDataURL(file)
+    // Reset input so same file can be re-selected
+    e.target.value = ""
+  }
+
+  const handleCropConfirm = async (crop: CropRect) => {
+    if (!rawSrc) return
+    setSaving(true)
+    try {
+      const dataUrl = await cropImage(rawSrc, crop)
+      setPreview(dataUrl)
+      setCropping(false)
+      setRawSrc(null)
+      onSave(dataUrl)
+    } catch {
+      setError("Failed to process image.")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleCropCancel = () => {
+    setCropping(false)
+    setRawSrc(null)
+    setNaturalSize(null)
+  }
+
+  const handleRemove = () => {
+    setPreview(null)
+    setRawSrc(null)
+    setCropping(false)
+    setError(null)
+  }
+
+  return (
+    <div className="border border-terminal-green/30 bg-terminal-black font-terminal-mono p-4 space-y-4" aria-label="Organization logo upload">
+      <div className="text-[10px] text-terminal-green tracking-widest">[ORG_LOGO]</div>
+
+      {/* Current preview */}
+      {preview && !cropping && (
+        <div className="flex items-center gap-4">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={preview}
+            alt="Organization logo preview"
+            width={64}
+            height={64}
+            className="w-16 h-16 object-cover border border-terminal-green/30"
+            data-testid="logo-preview"
+          />
+          <button
+            type="button"
+            onClick={handleRemove}
+            className="text-[9px] text-terminal-danger hover:text-terminal-danger/80 transition-colors"
+            aria-label="Remove logo"
+          >
+            REMOVE
+          </button>
+        </div>
+      )}
+
+      {/* Crop tool */}
+      {cropping && rawSrc && naturalSize && (
+        <CropTool
+          src={rawSrc}
+          naturalWidth={naturalSize.w}
+          naturalHeight={naturalSize.h}
+          onConfirm={handleCropConfirm}
+          onCancel={handleCropCancel}
+        />
+      )}
+
+      {/* Upload button */}
+      {!cropping && (
+        <div className="space-y-2">
+          <input
+            ref={inputRef}
+            type="file"
+            accept={ACCEPTED.join(",")}
+            onChange={handleFileChange}
+            className="sr-only"
+            aria-label="Upload logo file"
+            data-testid="logo-file-input"
+          />
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={saving}
+            className="text-[10px] px-4 py-2 border border-terminal-green/60 text-terminal-green hover:bg-terminal-green/10 transition-colors disabled:opacity-50"
+          >
+            {saving ? "PROCESSING…" : preview ? "CHANGE_LOGO" : "UPLOAD_LOGO"}
+          </button>
+          <div className="text-[9px] text-terminal-gray/60">
+            PNG, JPEG, GIF, WEBP · max {(maxSizeBytes / 1024 / 1024).toFixed(0)} MB
+          </div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="text-[10px] text-terminal-danger" role="alert" data-testid="logo-error">
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/soroscan-frontend/components/ui/TimeRangePicker.tsx
+++ b/soroscan-frontend/components/ui/TimeRangePicker.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import * as React from "react"
+
+export interface TimeRange {
+  from: Date
+  to: Date
+  timezone: string
+}
+
+interface TimeRangePickerProps {
+  value?: TimeRange
+  onChange: (range: TimeRange) => void
+  className?: string
+}
+
+const PRESETS = [
+  { label: "Last 1h",  minutes: 60 },
+  { label: "Last 24h", minutes: 1440 },
+  { label: "Last 7d",  minutes: 10080 },
+  { label: "Last 30d", minutes: 43200 },
+] as const
+
+const TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Asia/Singapore",
+  "Australia/Sydney",
+]
+
+function toLocalInput(date: Date, tz: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", hour12: false,
+    }).formatToParts(date)
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00"
+    return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}`
+  } catch {
+    return ""
+  }
+}
+
+function fromLocalInput(value: string, tz: string): Date {
+  // Parse the datetime-local string as if it's in the given timezone
+  const [datePart, timePart] = value.split("T")
+  const [year, month, day] = datePart.split("-").map(Number)
+  const [hour, minute] = (timePart ?? "00:00").split(":").map(Number)
+  // Use Intl to find the UTC offset for this tz at this moment
+  const naive = new Date(Date.UTC(year, month - 1, day, hour, minute))
+  const offsetMs = getTimezoneOffsetMs(naive, tz)
+  return new Date(naive.getTime() - offsetMs)
+}
+
+function getTimezoneOffsetMs(date: Date, tz: string): number {
+  const utcStr = date.toLocaleString("en-US", { timeZone: "UTC" })
+  const tzStr  = date.toLocaleString("en-US", { timeZone: tz })
+  return new Date(utcStr).getTime() - new Date(tzStr).getTime()
+}
+
+function formatUTC(date: Date): string {
+  return date.toISOString().replace("T", " ").slice(0, 16) + " UTC"
+}
+
+export function TimeRangePicker({ value, onChange, className = "" }: TimeRangePickerProps) {
+  const now = new Date()
+  const defaultRange: TimeRange = {
+    from: new Date(now.getTime() - 60 * 60 * 1000),
+    to: now,
+    timezone: "UTC",
+  }
+  const range = value ?? defaultRange
+
+  const [tz, setTz] = React.useState(range.timezone)
+  const [fromInput, setFromInput] = React.useState(() => toLocalInput(range.from, range.timezone))
+  const [toInput, setToInput]     = React.useState(() => toLocalInput(range.to,   range.timezone))
+  const [activePreset, setActivePreset] = React.useState<number | null>(null)
+
+  // Sync inputs when tz changes
+  React.useEffect(() => {
+    setFromInput(toLocalInput(range.from, tz))
+    setToInput(toLocalInput(range.to, tz))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tz])
+
+  const applyPreset = (minutes: number, idx: number) => {
+    const to   = new Date()
+    const from = new Date(to.getTime() - minutes * 60 * 1000)
+    setActivePreset(idx)
+    setFromInput(toLocalInput(from, tz))
+    setToInput(toLocalInput(to, tz))
+    onChange({ from, to, timezone: tz })
+  }
+
+  const handleFromChange = (v: string) => {
+    setFromInput(v)
+    setActivePreset(null)
+    if (v) {
+      const from = fromLocalInput(v, tz)
+      const to   = toInput ? fromLocalInput(toInput, tz) : range.to
+      onChange({ from, to, timezone: tz })
+    }
+  }
+
+  const handleToChange = (v: string) => {
+    setToInput(v)
+    setActivePreset(null)
+    if (v) {
+      const from = fromInput ? fromLocalInput(fromInput, tz) : range.from
+      const to   = fromLocalInput(v, tz)
+      onChange({ from, to, timezone: tz })
+    }
+  }
+
+  const handleTzChange = (newTz: string) => {
+    setTz(newTz)
+    onChange({ from: range.from, to: range.to, timezone: newTz })
+  }
+
+  return (
+    <div className={`border border-terminal-green/30 bg-terminal-black p-4 font-terminal-mono space-y-4 ${className}`} role="group" aria-label="Time range picker">
+      {/* Presets */}
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((p, i) => (
+          <button
+            key={p.label}
+            type="button"
+            onClick={() => applyPreset(p.minutes, i)}
+            className={`text-[10px] px-3 py-1 border transition-colors ${
+              activePreset === i
+                ? "border-terminal-green bg-terminal-green/20 text-terminal-green"
+                : "border-terminal-green/30 text-terminal-gray hover:border-terminal-green hover:text-terminal-green"
+            }`}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Custom inputs */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="space-y-1">
+          <span className="text-[10px] text-terminal-gray">FROM</span>
+          <input
+            type="datetime-local"
+            value={fromInput}
+            onChange={(e) => handleFromChange(e.target.value)}
+            className="w-full bg-transparent border border-terminal-green/30 text-terminal-green text-[11px] px-2 py-1.5 focus:outline-none focus:border-terminal-green"
+            aria-label="From date and time"
+          />
+          {fromInput && (
+            <div className="text-[9px] text-terminal-gray/60">{formatUTC(fromLocalInput(fromInput, tz))}</div>
+          )}
+        </label>
+
+        <label className="space-y-1">
+          <span className="text-[10px] text-terminal-gray">TO</span>
+          <input
+            type="datetime-local"
+            value={toInput}
+            onChange={(e) => handleToChange(e.target.value)}
+            className="w-full bg-transparent border border-terminal-green/30 text-terminal-green text-[11px] px-2 py-1.5 focus:outline-none focus:border-terminal-green"
+            aria-label="To date and time"
+          />
+          {toInput && (
+            <div className="text-[9px] text-terminal-gray/60">{formatUTC(fromLocalInput(toInput, tz))}</div>
+          )}
+        </label>
+      </div>
+
+      {/* Timezone */}
+      <label className="flex items-center gap-3">
+        <span className="text-[10px] text-terminal-gray shrink-0">TIMEZONE</span>
+        <select
+          value={tz}
+          onChange={(e) => handleTzChange(e.target.value)}
+          className="flex-1 bg-transparent border border-terminal-green/30 text-terminal-green text-[11px] px-2 py-1.5 focus:outline-none focus:border-terminal-green"
+          aria-label="Timezone"
+        >
+          {TIMEZONES.map((t) => (
+            <option key={t} value={t} className="bg-[#0a0e27]">{t}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}


### PR DESCRIPTION
this 
Closes #574 
Closes #568 
Closes #541 
Closes #540 


- #541 TimeRangePicker: presets (1h/24h/7d/30d), custom datetime-local inputs, timezone selector, UTC display
- #540 AdvancedFilterBuilder: AND/OR logic, multiple conditions with field/operator/value, filter preview, save/load/delete templates
- #568 WebhookTable: responsive stacked mobile cards with collapsible details and touch-friendly buttons (min 44px), desktop table unchanged
- #574 OrgLogoUpload: file upload UI, type/size validation, image preview, canvas-based square crop tool

62 tests passing across 4 suites