### PR TITLE
feat : Implemented Filter Expression Builder

### DIFF
--- a/soroscan-frontend/__tests__/filter-expression-tester.test.tsx
+++ b/soroscan-frontend/__tests__/filter-expression-tester.test.tsx
@@ -1,0 +1,347 @@
+import React from "react"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
+import { FilterExpressionTester, evaluateExpression } from "@/components/ui/FilterExpressionTester"
+import { emptyExpression, type FilterExpression } from "@/components/ui/WebhookFilterExpressionBuilder"
+
+// ── Unit: evaluateExpression ──────────────────────────────────────────────────
+
+describe("evaluateExpression", () => {
+  const payload = {
+    event_type: "SWAP_COMPLETE",
+    contract_id: "CABC...9X4Z",
+    amount: 1500,
+    ledger: 52300,
+    success: true,
+    from_address: "GDEX...A1B2",
+    topic: "soroscan/swap",
+  }
+
+  function makeExpr(field: string, operator: string, value: string): FilterExpression {
+    return {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field, operator: operator as never, value },
+        ],
+      },
+    }
+  }
+
+  it("passes eq condition when values match", () => {
+    const result = evaluateExpression(makeExpr("event_type", "eq", "SWAP_COMPLETE"), payload)
+    expect(result.passed).toBe(true)
+    expect(result.conditionResults[0].passed).toBe(true)
+  })
+
+  it("fails eq condition when values differ", () => {
+    const result = evaluateExpression(makeExpr("event_type", "eq", "LIQUIDITY_ADD"), payload)
+    expect(result.passed).toBe(false)
+  })
+
+  it("passes neq condition when values differ", () => {
+    const result = evaluateExpression(makeExpr("event_type", "neq", "LIQUIDITY_ADD"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes contains condition", () => {
+    const result = evaluateExpression(makeExpr("topic", "contains", "swap"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("fails not_contains when value is present", () => {
+    const result = evaluateExpression(makeExpr("topic", "not_contains", "swap"), payload)
+    expect(result.passed).toBe(false)
+  })
+
+  it("passes starts_with", () => {
+    const result = evaluateExpression(makeExpr("topic", "starts_with", "soroscan"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes ends_with", () => {
+    const result = evaluateExpression(makeExpr("topic", "ends_with", "swap"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes gt condition for numeric field", () => {
+    const result = evaluateExpression(makeExpr("amount", "gt", "1000"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("fails gt condition when value is not greater", () => {
+    const result = evaluateExpression(makeExpr("amount", "gt", "2000"), payload)
+    expect(result.passed).toBe(false)
+  })
+
+  it("passes gte condition at boundary", () => {
+    const result = evaluateExpression(makeExpr("amount", "gte", "1500"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes lt condition", () => {
+    const result = evaluateExpression(makeExpr("ledger", "lt", "60000"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes lte condition at boundary", () => {
+    const result = evaluateExpression(makeExpr("ledger", "lte", "52300"), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes in condition when value is in list", () => {
+    const result = evaluateExpression(
+      makeExpr("event_type", "in", "SWAP_COMPLETE, LIQUIDITY_ADD"),
+      payload
+    )
+    expect(result.passed).toBe(true)
+  })
+
+  it("fails in condition when value is not in list", () => {
+    const result = evaluateExpression(
+      makeExpr("event_type", "in", "GOV_PROPOSAL, ORACLE_UPDATE"),
+      payload
+    )
+    expect(result.passed).toBe(false)
+  })
+
+  it("passes not_in when value is absent", () => {
+    const result = evaluateExpression(
+      makeExpr("event_type", "not_in", "GOV_PROPOSAL, ORACLE_UPDATE"),
+      payload
+    )
+    expect(result.passed).toBe(true)
+  })
+
+  it("passes exists when field is present", () => {
+    const result = evaluateExpression(makeExpr("contract_id", "exists", ""), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("fails exists when field is absent", () => {
+    const result = evaluateExpression(makeExpr("nonexistent_field", "exists", ""), payload)
+    expect(result.passed).toBe(false)
+  })
+
+  it("passes not_exists when field is absent", () => {
+    const result = evaluateExpression(makeExpr("nonexistent_field", "not_exists", ""), payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("evaluates AND group: all must pass", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "SWAP_COMPLETE" },
+          { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "999" },
+        ],
+      },
+    }
+    const result = evaluateExpression(expr, payload)
+    expect(result.passed).toBe(true)
+    expect(result.conditionResults).toHaveLength(2)
+    expect(result.conditionResults.every((r) => r.passed)).toBe(true)
+  })
+
+  it("fails AND group when one condition fails", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "SWAP_COMPLETE" },
+          { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "99999" },
+        ],
+      },
+    }
+    const result = evaluateExpression(expr, payload)
+    expect(result.passed).toBe(false)
+    expect(result.conditionResults.some((r) => r.passed)).toBe(true)
+    expect(result.conditionResults.some((r) => !r.passed)).toBe(true)
+  })
+
+  it("passes OR group when only one condition passes", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "OR",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "LIQUIDITY_ADD" },
+          { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "999" },
+        ],
+      },
+    }
+    const result = evaluateExpression(expr, payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("fails OR group when all conditions fail", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "OR",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "LIQUIDITY_ADD" },
+          { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "99999" },
+        ],
+      },
+    }
+    const result = evaluateExpression(expr, payload)
+    expect(result.passed).toBe(false)
+  })
+
+  it("evaluates nested groups: (A AND B) OR C", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "OR",
+        children: [
+          {
+            id: "g2",
+            kind: "group",
+            logic: "AND",
+            children: [
+              // Both fail
+              { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "LIQUIDITY_ADD" },
+              { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "99999" },
+            ],
+          },
+          // This passes
+          { id: "c3", kind: "condition", field: "success", operator: "eq", value: "true" },
+        ],
+      },
+    }
+    const result = evaluateExpression(expr, payload)
+    expect(result.passed).toBe(true)
+  })
+
+  it("returns conditionResults with field/operator/value/actual", () => {
+    const result = evaluateExpression(makeExpr("amount", "gt", "1000"), payload)
+    expect(result.conditionResults[0]).toMatchObject({
+      field: "amount",
+      operator: "gt",
+      value: "1000",
+      actual: 1500,
+    })
+  })
+
+  it("includes reason string in each result", () => {
+    const result = evaluateExpression(makeExpr("event_type", "eq", "SWAP_COMPLETE"), payload)
+    expect(typeof result.conditionResults[0].reason).toBe("string")
+    expect(result.conditionResults[0].reason.length).toBeGreaterThan(0)
+  })
+
+  it("returns serialized expression string", () => {
+    const result = evaluateExpression(makeExpr("amount", "gt", "1000"), payload)
+    expect(typeof result.serialized).toBe("string")
+    expect(result.serialized).toContain("amount")
+  })
+
+  it("handles empty group (passes trivially)", () => {
+    const emptyExpr = { root: { id: "g1", kind: "group" as const, logic: "AND" as const, children: [] } }
+    const result = evaluateExpression(emptyExpr, payload)
+    expect(result.passed).toBe(true)
+    expect(result.conditionResults).toHaveLength(0)
+  })
+})
+
+// ── Component: FilterExpressionTester ────────────────────────────────────────
+
+describe("FilterExpressionTester component", () => {
+  function makeSimpleExpr(eventType: string): FilterExpression {
+    return {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: eventType },
+        ],
+      },
+    }
+  }
+
+  it("renders the tester container", () => {
+    render(<FilterExpressionTester expression={emptyExpression()} />)
+    expect(screen.getByTestId("filter-expression-tester")).toBeInTheDocument()
+  })
+
+  it("renders the RUN_TEST button", () => {
+    render(<FilterExpressionTester expression={emptyExpression()} />)
+    expect(screen.getByTestId("run-test-btn")).toBeInTheDocument()
+  })
+
+  it("renders the sample payload textarea pre-filled with JSON", () => {
+    render(<FilterExpressionTester expression={emptyExpression()} />)
+    const textarea = screen.getByLabelText("Sample JSON payload")
+    expect(textarea).toBeInTheDocument()
+    // Should contain the default sample
+    expect((textarea as HTMLTextAreaElement).value).toContain("event_type")
+  })
+
+  it("shows a passing verdict when expression matches payload", async () => {
+    const expr = makeSimpleExpr("SWAP_COMPLETE") // default sample has this
+    render(<FilterExpressionTester expression={expr} />)
+    fireEvent.click(screen.getByTestId("run-test-btn"))
+    await waitFor(() => {
+      expect(screen.getByTestId("test-verdict")).toBeInTheDocument()
+    }, { timeout: 1000 })
+    expect(screen.getByTestId("test-verdict").textContent).toContain("FILTER_MATCH")
+  })
+
+  it("shows a failing verdict when expression does not match payload", async () => {
+    const expr = makeSimpleExpr("LIQUIDITY_ADD") // default sample has SWAP_COMPLETE
+    render(<FilterExpressionTester expression={expr} />)
+    fireEvent.click(screen.getByTestId("run-test-btn"))
+    await waitFor(() => {
+      expect(screen.getByTestId("test-verdict")).toBeInTheDocument()
+    }, { timeout: 1000 })
+    expect(screen.getByTestId("test-verdict").textContent).toContain("NO_MATCH")
+  })
+
+  it("shows per-condition result rows after running", async () => {
+    const expr = makeSimpleExpr("SWAP_COMPLETE")
+    render(<FilterExpressionTester expression={expr} />)
+    fireEvent.click(screen.getByTestId("run-test-btn"))
+    await waitFor(() => {
+      expect(screen.getAllByTestId("condition-result-row")).toHaveLength(1)
+    }, { timeout: 1000 })
+  })
+
+  it("shows a JSON parse error when payload is invalid JSON", () => {
+    render(<FilterExpressionTester expression={emptyExpression()} />)
+    const textarea = screen.getByLabelText("Sample JSON payload")
+    fireEvent.change(textarea, { target: { value: "not valid json {{" } })
+    fireEvent.click(screen.getByTestId("run-test-btn"))
+    expect(screen.getByText(/invalid json/i)).toBeInTheDocument()
+    expect(screen.queryByTestId("test-results")).not.toBeInTheDocument()
+  })
+
+  it("resets payload to default when RESET is clicked", () => {
+    render(<FilterExpressionTester expression={emptyExpression()} />)
+    const textarea = screen.getByLabelText("Sample JSON payload")
+    fireEvent.change(textarea, { target: { value: '{"foo":"bar"}' } })
+    expect((textarea as HTMLTextAreaElement).value).toBe('{"foo":"bar"}')
+    fireEvent.click(screen.getByLabelText("Reset sample payload"))
+    expect((textarea as HTMLTextAreaElement).value).toContain("event_type")
+  })
+
+  it("clears results when payload is edited after running", async () => {
+    const expr = makeSimpleExpr("SWAP_COMPLETE")
+    render(<FilterExpressionTester expression={expr} />)
+    fireEvent.click(screen.getByTestId("run-test-btn"))
+    await waitFor(() => expect(screen.getByTestId("test-verdict")).toBeInTheDocument(), { timeout: 1000 })
+    // Edit the textarea — results should clear
+    const textarea = screen.getByLabelText("Sample JSON payload")
+    fireEvent.change(textarea, { target: { value: '{"event_type":"LIQUIDITY_ADD"}' } })
+    expect(screen.queryByTestId("test-results")).not.toBeInTheDocument()
+  })
+})

--- a/soroscan-frontend/__tests__/webhook-filter-expression-builder.test.tsx
+++ b/soroscan-frontend/__tests__/webhook-filter-expression-builder.test.tsx
@@ -1,0 +1,321 @@
+import React from "react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
+import {
+  WebhookFilterExpressionBuilder,
+  emptyExpression,
+  serializeExpression,
+  type FilterExpression,
+} from "@/components/ui/WebhookFilterExpressionBuilder"
+
+const mockOnChange = jest.fn()
+const mockOnApply = jest.fn()
+
+beforeEach(() => {
+  mockOnChange.mockClear()
+  mockOnApply.mockClear()
+})
+
+function renderBuilder(props: Partial<React.ComponentProps<typeof WebhookFilterExpressionBuilder>> = {}) {
+  return render(
+    <WebhookFilterExpressionBuilder
+      onChange={mockOnChange}
+      onApply={mockOnApply}
+      {...props}
+    />
+  )
+}
+
+// ── Unit: serializer ─────────────────────────────────────────────────────────
+
+describe("serializeExpression", () => {
+  it("serializes a simple eq condition", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "SWAP_COMPLETE" },
+        ],
+      },
+    }
+    expect(serializeExpression(expr)).toBe('event_type = "SWAP_COMPLETE"')
+  })
+
+  it("serializes AND group with two conditions", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "SWAP_COMPLETE" },
+          { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "1000" },
+        ],
+      },
+    }
+    const result = serializeExpression(expr)
+    expect(result).toContain("AND")
+    expect(result).toContain("event_type")
+    expect(result).toContain("amount")
+  })
+
+  it("serializes OR group", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "OR",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "SWAP_COMPLETE" },
+          { id: "c2", kind: "condition", field: "event_type", operator: "eq", value: "LIQUIDITY_ADD" },
+        ],
+      },
+    }
+    expect(serializeExpression(expr)).toContain("OR")
+  })
+
+  it("serializes exists operator without value", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "contract_id", operator: "exists", value: "" },
+        ],
+      },
+    }
+    expect(serializeExpression(expr)).toBe("EXISTS(contract_id)")
+  })
+
+  it("serializes IN operator with csv values", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "in", value: "SWAP_COMPLETE, LIQUIDITY_ADD" },
+        ],
+      },
+    }
+    const result = serializeExpression(expr)
+    expect(result).toContain("IN")
+    expect(result).toContain("SWAP_COMPLETE")
+    expect(result).toContain("LIQUIDITY_ADD")
+  })
+
+  it("wraps nested group in parentheses", () => {
+    const expr: FilterExpression = {
+      root: {
+        id: "g1",
+        kind: "group",
+        logic: "AND",
+        children: [
+          { id: "c1", kind: "condition", field: "event_type", operator: "eq", value: "SWAP_COMPLETE" },
+          {
+            id: "g2",
+            kind: "group",
+            logic: "OR",
+            children: [
+              { id: "c2", kind: "condition", field: "amount", operator: "gt", value: "1000" },
+              { id: "c3", kind: "condition", field: "amount", operator: "lt", value: "50" },
+            ],
+          },
+        ],
+      },
+    }
+    const result = serializeExpression(expr)
+    expect(result).toContain("(")
+    expect(result).toContain("AND")
+    expect(result).toContain("OR")
+  })
+
+  it("returns (empty) for empty root group", () => {
+    const expr: FilterExpression = {
+      root: { id: "g1", kind: "group", logic: "AND", children: [] },
+    }
+    expect(serializeExpression(expr)).toBe("(empty)")
+  })
+})
+
+// ── Unit: emptyExpression ─────────────────────────────────────────────────────
+
+describe("emptyExpression", () => {
+  it("creates a group with one default condition", () => {
+    const expr = emptyExpression()
+    expect(expr.root.kind).toBe("group")
+    expect(expr.root.children).toHaveLength(1)
+    expect(expr.root.children[0].kind).toBe("condition")
+  })
+
+  it("defaults to AND logic", () => {
+    expect(emptyExpression().root.logic).toBe("AND")
+  })
+})
+
+// ── Component tests ───────────────────────────────────────────────────────────
+
+describe("WebhookFilterExpressionBuilder component", () => {
+  it("renders accessible group and at least one condition row", () => {
+    renderBuilder()
+    expect(screen.getByRole("group", { name: /webhook filter expression builder/i })).toBeInTheDocument()
+    expect(screen.getAllByTestId("webhook-filter-condition")).toHaveLength(1)
+  })
+
+  it("renders root group with [ROOT] label", () => {
+    renderBuilder()
+    expect(screen.getByTestId("webhook-filter-root-group")).toBeInTheDocument()
+    expect(screen.getByText("[ROOT]")).toBeInTheDocument()
+  })
+
+  it("renders AND and OR logic toggle buttons", () => {
+    renderBuilder()
+    expect(screen.getByTestId("logic-and-btn")).toBeInTheDocument()
+    expect(screen.getByTestId("logic-or-btn")).toBeInTheDocument()
+  })
+
+  it("AND is pressed by default", () => {
+    renderBuilder()
+    expect(screen.getByTestId("logic-and-btn")).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByTestId("logic-or-btn")).toHaveAttribute("aria-pressed", "false")
+  })
+
+  it("switches to OR logic when OR is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByTestId("logic-or-btn"))
+    expect(screen.getByTestId("logic-or-btn")).toHaveAttribute("aria-pressed", "true")
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: expect.objectContaining({ logic: "OR" }),
+      })
+    )
+  })
+
+  it("adds a condition when ADD_CONDITION button is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByTestId("add-condition-btn"))
+    expect(screen.getAllByTestId("webhook-filter-condition")).toHaveLength(2)
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  it("removes a condition when the remove button is clicked", () => {
+    renderBuilder()
+    // Add a second condition first
+    fireEvent.click(screen.getByTestId("add-condition-btn"))
+    expect(screen.getAllByTestId("webhook-filter-condition")).toHaveLength(2)
+    // Remove the first
+    fireEvent.click(screen.getAllByTestId("remove-condition-btn")[0])
+    expect(screen.getAllByTestId("webhook-filter-condition")).toHaveLength(1)
+  })
+
+  it("adds a sub-group when GROUP button is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByTestId("add-group-btn"))
+    expect(screen.getByTestId("webhook-filter-sub-group")).toBeInTheDocument()
+  })
+
+  it("updates field select and calls onChange", () => {
+    renderBuilder()
+    const fieldSelect = screen.getAllByLabelText("Filter field")[0]
+    fireEvent.change(fieldSelect, { target: { value: "amount" } })
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: expect.objectContaining({
+          children: expect.arrayContaining([
+            expect.objectContaining({ field: "amount" }),
+          ]),
+        }),
+      })
+    )
+  })
+
+  it("updates operator select and calls onChange", () => {
+    renderBuilder()
+    const opSelect = screen.getAllByLabelText("Filter operator")[0]
+    fireEvent.change(opSelect, { target: { value: "neq" } })
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: expect.objectContaining({
+          children: expect.arrayContaining([
+            expect.objectContaining({ operator: "neq" }),
+          ]),
+        }),
+      })
+    )
+  })
+
+  it("updates value input and calls onChange", () => {
+    renderBuilder()
+    const valueInput = screen.getAllByLabelText("Filter value")[0]
+    fireEvent.change(valueInput, { target: { value: "SWAP_COMPLETE" } })
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: expect.objectContaining({
+          children: expect.arrayContaining([
+            expect.objectContaining({ value: "SWAP_COMPLETE" }),
+          ]),
+        }),
+      })
+    )
+  })
+
+  it("renders live expression preview", () => {
+    renderBuilder()
+    expect(screen.getByTestId("filter-expression-preview")).toBeInTheDocument()
+  })
+
+  it("updates expression preview when value changes", () => {
+    renderBuilder()
+    // Switch the default enum field to a string field so we get a text input
+    const fieldSelect = screen.getAllByLabelText("Filter field")[0]
+    fireEvent.change(fieldSelect, { target: { value: "contract_id" } })
+    const valueInput = screen.getAllByLabelText("Filter value")[0]
+    fireEvent.change(valueInput, { target: { value: "myvalue" } })
+    const preview = screen.getByTestId("filter-expression-preview")
+    expect(preview.textContent).toContain("myvalue")
+  })
+
+  it("calls onApply with expression when APPLY_FILTER is clicked", () => {
+    renderBuilder()
+    fireEvent.click(screen.getByTestId("apply-expression-btn"))
+    expect(mockOnApply).toHaveBeenCalledTimes(1)
+    expect(mockOnApply).toHaveBeenCalledWith(
+      expect.objectContaining({ root: expect.any(Object) }),
+      expect.any(String)
+    )
+  })
+
+  it("resets to empty expression on RESET click", () => {
+    renderBuilder()
+    // Add extra condition
+    fireEvent.click(screen.getByTestId("add-condition-btn"))
+    expect(screen.getAllByTestId("webhook-filter-condition")).toHaveLength(2)
+    fireEvent.click(screen.getByTestId("reset-expression-btn"))
+    expect(screen.getAllByTestId("webhook-filter-condition")).toHaveLength(1)
+  })
+
+  it("syncs external value prop when changed", () => {
+    const initial = emptyExpression()
+    const { rerender } = renderBuilder({ value: initial })
+    const newExpr: FilterExpression = {
+      root: {
+        id: "g_new",
+        kind: "group",
+        logic: "OR",
+        children: [
+          { id: "c_new", kind: "condition", field: "amount", operator: "gt", value: "500" },
+        ],
+      },
+    }
+    rerender(
+      <WebhookFilterExpressionBuilder
+        value={newExpr}
+        onChange={mockOnChange}
+        onApply={mockOnApply}
+      />
+    )
+    expect(screen.getByTestId("logic-or-btn")).toHaveAttribute("aria-pressed", "true")
+  })
+})

--- a/soroscan-frontend/app/webhooks/components/CreateWebhookModal.tsx
+++ b/soroscan-frontend/app/webhooks/components/CreateWebhookModal.tsx
@@ -1,10 +1,13 @@
 "use client"
 
 import * as React from "react"
+import { Wand2 } from "lucide-react"
 import { Modal } from "@/components/terminal/Modal"
 import { Input } from "@/components/terminal/Input"
 import { Button } from "@/components/terminal/Button"
+import { FilterBuilderModal } from "./FilterBuilderModal"
 import type { Webhook, EventType, WebhookStatus } from "../types"
+import type { FilterExpression } from "@/components/ui/WebhookFilterExpressionBuilder"
 
 const ALL_EVENT_TYPES: EventType[] = [
   "ALL",
@@ -42,6 +45,11 @@ export function CreateWebhookModal({ isOpen, onClose, onCreate }: CreateWebhookM
   const [timeoutTouched, setTimeoutTouched] = React.useState(false)
   const [submitting, setSubmitting] = React.useState(false)
 
+  // Filter expression state
+  const [filterExpression, setFilterExpression] = React.useState<FilterExpression | undefined>(undefined)
+  const [filterExpressionStr, setFilterExpressionStr] = React.useState<string>("")
+  const [filterBuilderOpen, setFilterBuilderOpen] = React.useState(false)
+
   const urlValid = isValidUrl(url)
   const timeoutValue = Number(timeoutInput)
   const timeoutValid = Number.isInteger(timeoutValue) && timeoutValue >= 5 && timeoutValue <= 60
@@ -57,6 +65,16 @@ export function CreateWebhookModal({ isOpen, onClose, onCreate }: CreateWebhookM
       const without = prev.filter((x) => x !== "ALL")
       return without.includes(t) ? without.filter((x) => x !== t) : [...without, t]
     })
+  }
+
+  const handleSaveFilter = (exprStr: string, expr: FilterExpression) => {
+    setFilterExpressionStr(exprStr)
+    setFilterExpression(expr)
+  }
+
+  const handleClearFilter = () => {
+    setFilterExpression(undefined)
+    setFilterExpressionStr("")
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -76,10 +94,12 @@ export function CreateWebhookModal({ isOpen, onClose, onCreate }: CreateWebhookM
         contractFilter: contractFilter.trim() || undefined,
         status,
         timeoutSeconds: timeoutValue,
+        filterExpression: filterExpressionStr || undefined,
       })
       // reset
       setUrl(""); setUrlTouched(false); setSelectedTypes(["ALL"])
       setContractFilter(""); setStatus("ACTIVE"); setTimeoutInput("30"); setTimeoutTouched(false)
+      setFilterExpression(undefined); setFilterExpressionStr("")
       setSubmitting(false)
       onClose()
     }, 600)
@@ -88,138 +108,198 @@ export function CreateWebhookModal({ isOpen, onClose, onCreate }: CreateWebhookM
   const handleClose = () => {
     setUrl(""); setUrlTouched(false); setSelectedTypes(["ALL"])
     setContractFilter(""); setStatus("ACTIVE"); setTimeoutInput("30"); setTimeoutTouched(false)
+    setFilterExpression(undefined); setFilterExpressionStr("")
     onClose()
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="NEW_WEBHOOK_SUBSCRIPTION">
-      <form onSubmit={handleSubmit} className="space-y-5 text-sm">
-        {/* URL */}
-        <div>
-          <Input
-            id="webhook-url-input"
-            label="ENDPOINT_URL *"
-            type="url"
-            placeholder="https://yourapp.io/webhook"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            onBlur={() => setUrlTouched(true)}
-            aria-invalid={!!urlError}
-          />
-          {urlError && (
-            <p className="text-terminal-danger text-[10px] mt-1 ml-1">{urlError}</p>
-          )}
-        </div>
-
-        {/* Event timeout */}
-        <div>
-          <Input
-            id="timeout-input"
-            label="REQUEST_TIMEOUT (seconds)"
-            type="number"
-            min={5}
-            max={60}
-            step={1}
-            value={timeoutInput}
-            onChange={(e) => setTimeoutInput(e.target.value)}
-            onBlur={() => setTimeoutTouched(true)}
-            aria-invalid={!!timeoutError}
-          />
-          <div className="flex flex-wrap gap-2 mt-2">
-            {[10, 20, 30, 45, 60].map((value) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => {
-                  setTimeoutInput(String(value))
-                  setTimeoutTouched(true)
-                }}
-                className="rounded border border-terminal-green/20 px-3 py-1.5 text-[11px] text-terminal-gray transition hover:border-terminal-green hover:text-terminal-green"
-              >
-                {value}s
-              </button>
-            ))}
+    <>
+      <Modal isOpen={isOpen} onClose={handleClose} title="NEW_WEBHOOK_SUBSCRIPTION">
+        <form onSubmit={handleSubmit} className="space-y-5 text-sm">
+          {/* URL */}
+          <div>
+            <Input
+              id="webhook-url-input"
+              label="ENDPOINT_URL *"
+              type="url"
+              placeholder="https://yourapp.io/webhook"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onBlur={() => setUrlTouched(true)}
+              aria-invalid={!!urlError}
+            />
+            {urlError && (
+              <p className="text-terminal-danger text-[10px] mt-1 ml-1">{urlError}</p>
+            )}
           </div>
-          {timeoutError && (
-            <p className="text-terminal-danger text-[10px] mt-1 ml-1">{timeoutError}</p>
-          )}
-        </div>
 
-        {/* Event types */}
-        <div className="space-y-2">
-          <div className="text-xs text-terminal-cyan uppercase tracking-wider ml-1">EVENT_TYPES *</div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-            {ALL_EVENT_TYPES.map((t) => {
-              const checked = selectedTypes.includes(t)
-              return (
-                <label
-                  key={t}
-                  className={`flex items-center gap-2 cursor-pointer border px-2 py-1.5 text-[10px] transition-colors select-none ${
-                    checked
-                      ? "border-terminal-green text-terminal-green bg-terminal-green/5"
-                      : "border-terminal-gray/30 text-terminal-gray hover:border-terminal-green/50"
-                  }`}
+          {/* Event timeout */}
+          <div>
+            <Input
+              id="timeout-input"
+              label="REQUEST_TIMEOUT (seconds)"
+              type="number"
+              min={5}
+              max={60}
+              step={1}
+              value={timeoutInput}
+              onChange={(e) => setTimeoutInput(e.target.value)}
+              onBlur={() => setTimeoutTouched(true)}
+              aria-invalid={!!timeoutError}
+            />
+            <div className="flex flex-wrap gap-2 mt-2">
+              {[10, 20, 30, 45, 60].map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => {
+                    setTimeoutInput(String(value))
+                    setTimeoutTouched(true)
+                  }}
+                  className="rounded border border-terminal-green/20 px-3 py-1.5 text-[11px] text-terminal-gray transition hover:border-terminal-green hover:text-terminal-green"
                 >
+                  {value}s
+                </button>
+              ))}
+            </div>
+            {timeoutError && (
+              <p className="text-terminal-danger text-[10px] mt-1 ml-1">{timeoutError}</p>
+            )}
+          </div>
+
+          {/* Event types */}
+          <div className="space-y-2">
+            <div className="text-xs text-terminal-cyan uppercase tracking-wider ml-1">EVENT_TYPES *</div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {ALL_EVENT_TYPES.map((t) => {
+                const checked = selectedTypes.includes(t)
+                return (
+                  <label
+                    key={t}
+                    className={`flex items-center gap-2 cursor-pointer border px-2 py-1.5 text-[10px] transition-colors select-none ${
+                      checked
+                        ? "border-terminal-green text-terminal-green bg-terminal-green/5"
+                        : "border-terminal-gray/30 text-terminal-gray hover:border-terminal-green/50"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleType(t)}
+                      className="sr-only"
+                    />
+                    <span className={`w-2 h-2 border ${checked ? "bg-terminal-green border-terminal-green" : "border-terminal-gray/40"}`} />
+                    {t}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Contract filter */}
+          <Input
+            id="contract-filter-input"
+            label="CONTRACT_FILTER (optional)"
+            type="text"
+            placeholder="CABC...9X4Z — leave blank for all contracts"
+            value={contractFilter}
+            onChange={(e) => setContractFilter(e.target.value)}
+          />
+
+          {/* Filter expression builder */}
+          <div className="space-y-2">
+            <div className="text-xs text-terminal-cyan uppercase tracking-wider ml-1">
+              FILTER_EXPRESSION (optional)
+            </div>
+            {filterExpressionStr ? (
+              <div className="border border-terminal-green/30 bg-terminal-green/3 p-3 space-y-2">
+                <div className="text-[9px] text-terminal-gray tracking-widest">ACTIVE_FILTER</div>
+                <div
+                  className="text-[10px] text-terminal-cyan break-all leading-relaxed"
+                  data-testid="active-filter-expression"
+                >
+                  {filterExpressionStr}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setFilterBuilderOpen(true)}
+                    className="text-[9px] px-3 py-1 border border-terminal-green/30 text-terminal-green hover:border-terminal-green hover:bg-terminal-green/5 transition-colors flex items-center gap-1"
+                    data-testid="edit-filter-btn"
+                  >
+                    <Wand2 size={10} /> EDIT_FILTER
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleClearFilter}
+                    className="text-[9px] px-3 py-1 border border-terminal-danger/30 text-terminal-danger hover:border-terminal-danger hover:bg-terminal-danger/5 transition-colors"
+                    data-testid="clear-filter-btn"
+                  >
+                    CLEAR
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setFilterBuilderOpen(true)}
+                className="w-full border border-dashed border-terminal-green/30 text-terminal-gray hover:border-terminal-green hover:text-terminal-green transition-colors py-3 text-[11px] tracking-widest flex items-center justify-center gap-2"
+                data-testid="open-filter-builder-btn"
+              >
+                <Wand2 size={13} />
+                BUILD_FILTER_EXPRESSION
+              </button>
+            )}
+            <p className="text-[9px] text-terminal-gray/60 ml-1">
+              Define custom field conditions to filter which events trigger this webhook.
+            </p>
+          </div>
+
+          {/* Status */}
+          <div className="space-y-2">
+            <div className="text-xs text-terminal-cyan uppercase tracking-wider ml-1">INITIAL_STATUS</div>
+            <div className="flex gap-4">
+              {(["ACTIVE", "SUSPENDED"] as const).map((s) => (
+                <label key={s} className="flex items-center gap-2 cursor-pointer text-[11px] select-none">
                   <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => toggleType(t)}
+                    type="radio"
+                    name="status"
+                    value={s}
+                    checked={status === s}
+                    onChange={() => setStatus(s)}
                     className="sr-only"
                   />
-                  <span className={`w-2 h-2 border ${checked ? "bg-terminal-green border-terminal-green" : "border-terminal-gray/40"}`} />
-                  {t}
+                  <span className={`w-3 h-3 border-2 rounded-full ${status === s ? "border-terminal-green bg-terminal-green" : "border-terminal-gray/40"}`} />
+                  <span className={status === s ? "text-terminal-green" : "text-terminal-gray"}>{s}</span>
                 </label>
-              )
-            })}
+              ))}
+            </div>
           </div>
-        </div>
 
-        {/* Contract filter */}
-        <Input
-          id="contract-filter-input"
-          label="CONTRACT_FILTER (optional)"
-          type="text"
-          placeholder="CABC...9X4Z — leave blank for all contracts"
-          value={contractFilter}
-          onChange={(e) => setContractFilter(e.target.value)}
-        />
-
-        {/* Status */}
-        <div className="space-y-2">
-          <div className="text-xs text-terminal-cyan uppercase tracking-wider ml-1">INITIAL_STATUS</div>
-          <div className="flex gap-4">
-            {(["ACTIVE", "SUSPENDED"] as const).map((s) => (
-              <label key={s} className="flex items-center gap-2 cursor-pointer text-[11px] select-none">
-                <input
-                  type="radio"
-                  name="status"
-                  value={s}
-                  checked={status === s}
-                  onChange={() => setStatus(s)}
-                  className="sr-only"
-                />
-                <span className={`w-3 h-3 border-2 rounded-full ${status === s ? "border-terminal-green bg-terminal-green" : "border-terminal-gray/40"}`} />
-                <span className={status === s ? "text-terminal-green" : "text-terminal-gray"}>{s}</span>
-              </label>
-            ))}
+          {/* Submit */}
+          <div className="flex gap-3 pt-2">
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={submitting || (urlTouched && !urlValid)}
+              className="flex-1"
+            >
+              {submitting ? "CREATING..." : "CREATE_WEBHOOK"}
+            </Button>
+            <Button type="button" variant="danger" onClick={handleClose}>
+              CANCEL
+            </Button>
           </div>
-        </div>
+        </form>
+      </Modal>
 
-        {/* Submit */}
-        <div className="flex gap-3 pt-2">
-          <Button
-            type="submit"
-            variant="primary"
-            disabled={submitting || (urlTouched && !urlValid)}
-            className="flex-1"
-          >
-            {submitting ? "CREATING..." : "CREATE_WEBHOOK"}
-          </Button>
-          <Button type="button" variant="danger" onClick={handleClose}>
-            CANCEL
-          </Button>
-        </div>
-      </form>
-    </Modal>
+      {/* Filter expression builder modal */}
+      <FilterBuilderModal
+        isOpen={filterBuilderOpen}
+        onClose={() => setFilterBuilderOpen(false)}
+        onSave={handleSaveFilter}
+        initialExpression={filterExpression}
+      />
+    </>
   )
 }

--- a/soroscan-frontend/app/webhooks/components/FilterBuilderModal.tsx
+++ b/soroscan-frontend/app/webhooks/components/FilterBuilderModal.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import { FlaskConical, Wand2 } from "lucide-react"
+import { Modal } from "@/components/terminal/Modal"
+import {
+  WebhookFilterExpressionBuilder,
+  emptyExpression,
+  serializeExpression,
+  type FilterExpression,
+} from "@/components/ui/WebhookFilterExpressionBuilder"
+import { FilterExpressionTester } from "@/components/ui/FilterExpressionTester"
+
+export interface FilterBuilderModalProps {
+  isOpen: boolean
+  onClose: () => void
+  /** Called when the user confirms/saves the filter expression string */
+  onSave: (expressionString: string, expression: FilterExpression) => void
+  /** Pre-populate with an existing expression */
+  initialExpression?: FilterExpression
+}
+
+type Tab = "build" | "test"
+
+export function FilterBuilderModal({
+  isOpen,
+  onClose,
+  onSave,
+  initialExpression,
+}: FilterBuilderModalProps) {
+  const [expr, setExpr] = React.useState<FilterExpression>(initialExpression ?? emptyExpression())
+  const [activeTab, setActiveTab] = React.useState<Tab>("build")
+
+  // Reset when modal re-opens
+  React.useEffect(() => {
+    if (isOpen) {
+      setExpr(initialExpression ?? emptyExpression())
+      setActiveTab("build")
+    }
+  }, [isOpen, initialExpression])
+
+  const serialized = serializeExpression(expr)
+
+  const handleSave = () => {
+    onSave(serialized, expr)
+    onClose()
+  }
+
+  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+    { id: "build", label: "BUILD", icon: <Wand2 size={11} /> },
+    { id: "test",  label: "TEST",  icon: <FlaskConical size={11} /> },
+  ]
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="FILTER_EXPRESSION_BUILDER">
+      <div className="space-y-4 min-h-[400px]">
+        {/* Tab bar */}
+        <div className="flex border-b border-terminal-green/20" role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex items-center gap-1.5 px-4 py-2 text-[10px] tracking-widest border-b-2 transition-colors ${
+                activeTab === tab.id
+                  ? "border-terminal-green text-terminal-green"
+                  : "border-transparent text-terminal-gray hover:text-terminal-green/70"
+              }`}
+              data-testid={`tab-${tab.id}`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        {activeTab === "build" && (
+          <WebhookFilterExpressionBuilder
+            value={expr}
+            onChange={setExpr}
+          />
+        )}
+        {activeTab === "test" && (
+          <FilterExpressionTester expression={expr} />
+        )}
+
+        {/* Footer actions */}
+        <div className="flex gap-3 pt-2 border-t border-terminal-green/20">
+          <button
+            type="button"
+            onClick={handleSave}
+            className="flex-1 border border-terminal-green text-terminal-green py-2 text-[11px] tracking-widest hover:bg-terminal-green/10 transition-colors"
+            data-testid="save-filter-btn"
+          >
+            SAVE_FILTER
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border border-terminal-danger/40 text-terminal-danger px-4 py-2 text-[11px] hover:border-terminal-danger hover:bg-terminal-danger/5 transition-colors"
+            data-testid="cancel-filter-btn"
+          >
+            CANCEL
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/soroscan-frontend/app/webhooks/filter-builder/page.tsx
+++ b/soroscan-frontend/app/webhooks/filter-builder/page.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { ArrowLeft, Copy, Check, FlaskConical } from "lucide-react"
+import Link from "next/link"
+import { Navbar } from "@/components/terminal/landing/Navbar"
+import { Footer } from "@/components/terminal/landing/Footer"
+import {
+  WebhookFilterExpressionBuilder,
+  emptyExpression,
+  serializeExpression,
+  type FilterExpression,
+} from "@/components/ui/WebhookFilterExpressionBuilder"
+import { FilterExpressionTester } from "@/components/ui/FilterExpressionTester"
+
+export default function FilterBuilderPage() {
+  const [expr, setExpr] = React.useState<FilterExpression>(emptyExpression())
+  const [activeTab, setActiveTab] = React.useState<"build" | "test">("build")
+  const [copied, setCopied] = React.useState(false)
+
+  const serialized = serializeExpression(expr)
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(serialized).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className="min-h-screen font-terminal-mono selection:bg-terminal-green selection:text-terminal-black">
+      <Navbar />
+
+      <main className="container mx-auto px-6 md:px-8 py-10 md:py-14 space-y-8 max-w-5xl">
+
+        {/* Breadcrumb */}
+        <Link
+          href="/webhooks"
+          className="inline-flex items-center gap-2 text-[10px] text-terminal-gray hover:text-terminal-green transition-colors tracking-widest"
+        >
+          <ArrowLeft size={11} /> BACK_TO_WEBHOOKS
+        </Link>
+
+        {/* Header */}
+        <div>
+          <div className="text-[10px] text-terminal-cyan tracking-widest mb-1">[FILTER_EXPRESSION_BUILDER]</div>
+          <h1 className="text-3xl md:text-4xl font-bold text-terminal-green">
+            FILTER BUILDER
+          </h1>
+          <p className="text-terminal-gray text-xs mt-2 max-w-xl">
+            Construct complex filter expressions using nested AND/OR logic. Test your expression against
+            a sample event payload before attaching it to a webhook subscription.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+
+          {/* Builder panel — takes 3/5 width on large screens */}
+          <div className="lg:col-span-3 space-y-4">
+            {/* Tab bar */}
+            <div className="flex border-b border-terminal-green/20" role="tablist">
+              {([
+                { id: "build", label: "BUILD_EXPRESSION" },
+                { id: "test",  label: "TEST_EXPRESSION", icon: <FlaskConical size={11} /> },
+              ] as const).map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`flex items-center gap-1.5 px-4 py-2 text-[10px] tracking-widest border-b-2 transition-colors ${
+                    activeTab === tab.id
+                      ? "border-terminal-green text-terminal-green"
+                      : "border-transparent text-terminal-gray hover:text-terminal-green/70"
+                  }`}
+                  data-testid={`page-tab-${tab.id}`}
+                >
+                  {"icon" in tab && tab.icon}
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            <div role="tabpanel">
+              {activeTab === "build" ? (
+                <WebhookFilterExpressionBuilder
+                  value={expr}
+                  onChange={setExpr}
+                />
+              ) : (
+                <FilterExpressionTester expression={expr} />
+              )}
+            </div>
+          </div>
+
+          {/* Sidebar — expression output + help */}
+          <div className="lg:col-span-2 space-y-4">
+
+            {/* Generated expression */}
+            <div className="border border-terminal-green/30">
+              <div className="flex items-center justify-between px-3 py-2 border-b border-terminal-green/20 bg-terminal-green/3">
+                <span className="text-[9px] text-terminal-green tracking-widest">GENERATED_EXPRESSION</span>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  disabled={!serialized}
+                  aria-label="Copy expression to clipboard"
+                  className="text-[9px] flex items-center gap-1 text-terminal-gray hover:text-terminal-green transition-colors disabled:opacity-40"
+                  data-testid="copy-expression-btn"
+                >
+                  {copied ? <Check size={11} /> : <Copy size={11} />}
+                  {copied ? "COPIED" : "COPY"}
+                </button>
+              </div>
+              <pre
+                className="px-3 py-3 text-[10px] text-terminal-cyan break-all whitespace-pre-wrap leading-relaxed min-h-[80px]"
+                data-testid="page-expression-preview"
+              >
+                {serialized || "(empty)"}
+              </pre>
+            </div>
+
+            {/* Quick reference */}
+            <div className="border border-terminal-green/20 space-y-0">
+              <div className="px-3 py-2 border-b border-terminal-green/20 bg-terminal-green/3">
+                <span className="text-[9px] text-terminal-green tracking-widest">QUICK_REFERENCE</span>
+              </div>
+              <div className="px-3 py-3 space-y-3 text-[10px] text-terminal-gray">
+                {[
+                  { sym: "=",         desc: "Exact match" },
+                  { sym: "!=",        desc: "Not equal" },
+                  { sym: "~=",        desc: "Contains substring" },
+                  { sym: "^=",        desc: "Starts with" },
+                  { sym: "$=",        desc: "Ends with" },
+                  { sym: "> / >=",    desc: "Greater than (numeric)" },
+                  { sym: "< / <=",    desc: "Less than (numeric)" },
+                  { sym: "IN [...]",  desc: "Matches any in list" },
+                  { sym: "EXISTS()",  desc: "Field is present" },
+                ].map((r) => (
+                  <div key={r.sym} className="flex items-start gap-3">
+                    <code className="text-terminal-cyan font-bold w-20 shrink-0">{r.sym}</code>
+                    <span>{r.desc}</span>
+                  </div>
+                ))}
+
+                <div className="border-t border-terminal-green/10 pt-3 space-y-1.5">
+                  <div className="text-[9px] text-terminal-cyan tracking-wider">BOOLEAN_LOGIC</div>
+                  <div className="flex gap-2">
+                    <code className="text-terminal-green font-bold w-8 shrink-0">AND</code>
+                    <span>All conditions must match</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <code className="text-terminal-cyan font-bold w-8 shrink-0">OR</code>
+                    <span>At least one must match</span>
+                  </div>
+                  <div className="mt-1 text-terminal-gray/60">
+                    Groups can be infinitely nested to build complex logic.
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Use expression CTA */}
+            <Link
+              href="/webhooks"
+              className="flex items-center justify-center gap-2 w-full border border-terminal-green/40 text-terminal-green py-3 text-[11px] tracking-widest hover:bg-terminal-green/10 transition-colors"
+              data-testid="use-expression-link"
+            >
+              USE IN WEBHOOK →
+            </Link>
+
+          </div>
+        </div>
+      </main>
+
+      <div className="container mx-auto px-6 md:px-8 max-w-5xl pb-12">
+        <Footer />
+      </div>
+
+      {/* Background grid */}
+      <div className="fixed inset-0 pointer-events-none z-[-1] overflow-hidden opacity-20">
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(0,255,65,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(0,255,65,0.03)_1px,transparent_1px)] bg-size-[40px_40px]" />
+      </div>
+    </div>
+  )
+}

--- a/soroscan-frontend/app/webhooks/types.ts
+++ b/soroscan-frontend/app/webhooks/types.ts
@@ -15,6 +15,8 @@ export interface Webhook {
   url: string
   eventTypes: EventType[]
   contractFilter?: string
+  /** Serialized filter expression built by the visual filter builder */
+  filterExpression?: string
   status: WebhookStatus
   createdAt: string
   lastDelivery?: string

--- a/soroscan-frontend/components/ui/FilterExpressionTester.tsx
+++ b/soroscan-frontend/components/ui/FilterExpressionTester.tsx
@@ -1,0 +1,369 @@
+"use client"
+
+import * as React from "react"
+import { CheckCircle2, XCircle, AlertTriangle, Play, RotateCcw } from "lucide-react"
+import type { FilterExpression, FilterNode, FilterGroup, FilterCondition, Operator } from "./WebhookFilterExpressionBuilder"
+import { serializeExpression } from "./WebhookFilterExpressionBuilder"
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface TestResult {
+  passed: boolean
+  conditionResults: ConditionResult[]
+  error?: string
+  serialized: string
+}
+
+export interface ConditionResult {
+  conditionId: string
+  field: string
+  operator: Operator
+  value: string
+  actual: unknown
+  passed: boolean
+  reason: string
+}
+
+// ── Evaluator ──────────────────────────────────────────────────────────────
+
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((cur, key) => {
+    if (cur !== null && cur !== undefined && typeof cur === "object") {
+      return (cur as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}
+
+function evaluateCondition(
+  cond: FilterCondition,
+  payload: Record<string, unknown>
+): ConditionResult {
+  const actual = getNestedValue(payload, cond.field)
+  const actualStr = String(actual ?? "")
+  const v = cond.value
+
+  let passed = false
+  let reason = ""
+
+  switch (cond.operator) {
+    case "eq":
+      passed = actualStr === v
+      reason = passed ? `${cond.field} = "${v}"` : `${cond.field} is "${actualStr}", expected "${v}"`
+      break
+    case "neq":
+      passed = actualStr !== v
+      reason = passed ? `${cond.field} ≠ "${v}"` : `${cond.field} equals "${v}" (should differ)`
+      break
+    case "contains":
+      passed = actualStr.includes(v)
+      reason = passed ? `"${actualStr}" contains "${v}"` : `"${actualStr}" does not contain "${v}"`
+      break
+    case "not_contains":
+      passed = !actualStr.includes(v)
+      reason = passed ? `"${actualStr}" does not contain "${v}"` : `"${actualStr}" contains "${v}"`
+      break
+    case "starts_with":
+      passed = actualStr.startsWith(v)
+      reason = passed ? `"${actualStr}" starts with "${v}"` : `"${actualStr}" does not start with "${v}"`
+      break
+    case "ends_with":
+      passed = actualStr.endsWith(v)
+      reason = passed ? `"${actualStr}" ends with "${v}"` : `"${actualStr}" does not end with "${v}"`
+      break
+    case "gt":
+      passed = Number(actual) > Number(v)
+      reason = passed ? `${actual} > ${v}` : `${actual} is not > ${v}`
+      break
+    case "gte":
+      passed = Number(actual) >= Number(v)
+      reason = passed ? `${actual} >= ${v}` : `${actual} is not >= ${v}`
+      break
+    case "lt":
+      passed = Number(actual) < Number(v)
+      reason = passed ? `${actual} < ${v}` : `${actual} is not < ${v}`
+      break
+    case "lte":
+      passed = Number(actual) <= Number(v)
+      reason = passed ? `${actual} <= ${v}` : `${actual} is not <= ${v}`
+      break
+    case "in": {
+      const vals = v.split(",").map((s) => s.trim())
+      passed = vals.includes(actualStr)
+      reason = passed ? `"${actualStr}" is in [${vals.join(", ")}]` : `"${actualStr}" not in [${vals.join(", ")}]`
+      break
+    }
+    case "not_in": {
+      const vals = v.split(",").map((s) => s.trim())
+      passed = !vals.includes(actualStr)
+      reason = passed ? `"${actualStr}" not in [${vals.join(", ")}]` : `"${actualStr}" is in [${vals.join(", ")}]`
+      break
+    }
+    case "exists":
+      passed = actual !== undefined && actual !== null && actual !== ""
+      reason = passed ? `${cond.field} exists` : `${cond.field} is absent or empty`
+      break
+    case "not_exists":
+      passed = actual === undefined || actual === null || actual === ""
+      reason = passed ? `${cond.field} is absent` : `${cond.field} exists with value "${actualStr}"`
+      break
+    default:
+      passed = false
+      reason = `Unknown operator "${cond.operator}"`
+  }
+
+  return { conditionId: cond.id, field: cond.field, operator: cond.operator, value: cond.value, actual, passed, reason }
+}
+
+function evaluateGroup(
+  group: FilterGroup,
+  payload: Record<string, unknown>,
+  results: ConditionResult[]
+): boolean {
+  if (group.children.length === 0) return true
+
+  const childResults: boolean[] = group.children.map((child) => evaluateNode(child, payload, results))
+
+  if (group.logic === "AND") return childResults.every(Boolean)
+  return childResults.some(Boolean)
+}
+
+function evaluateNode(
+  node: FilterNode,
+  payload: Record<string, unknown>,
+  results: ConditionResult[]
+): boolean {
+  if (node.kind === "condition") {
+    const r = evaluateCondition(node, payload)
+    results.push(r)
+    return r.passed
+  }
+  return evaluateGroup(node, payload, results)
+}
+
+export function evaluateExpression(expr: FilterExpression, payload: Record<string, unknown>): TestResult {
+  const conditionResults: ConditionResult[] = []
+  try {
+    const passed = evaluateGroup(expr.root, payload, conditionResults)
+    return { passed, conditionResults, serialized: serializeExpression(expr) }
+  } catch (err) {
+    return {
+      passed: false,
+      conditionResults,
+      error: err instanceof Error ? err.message : String(err),
+      serialized: serializeExpression(expr),
+    }
+  }
+}
+
+// ── Default sample payload ─────────────────────────────────────────────────
+
+const DEFAULT_SAMPLE = JSON.stringify(
+  {
+    event_type: "SWAP_COMPLETE",
+    contract_id: "CABC...9X4Z",
+    amount: 1500,
+    ledger: 52300,
+    timestamp: 1716000000,
+    from_address: "GDEX...A1B2",
+    to_address: "GCOL...K9L0",
+    asset_code: "USDC",
+    topic: "soroscan/swap",
+    success: true,
+  },
+  null,
+  2
+)
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export interface FilterExpressionTesterProps {
+  expression: FilterExpression
+  onClose?: () => void
+}
+
+export function FilterExpressionTester({ expression, onClose }: FilterExpressionTesterProps) {
+  const [sampleJson, setSampleJson] = React.useState(DEFAULT_SAMPLE)
+  const [jsonError, setJsonError] = React.useState<string | null>(null)
+  const [result, setResult] = React.useState<TestResult | null>(null)
+  const [running, setRunning] = React.useState(false)
+
+  const handleRun = () => {
+    setJsonError(null)
+    setResult(null)
+
+    let payload: Record<string, unknown>
+    try {
+      payload = JSON.parse(sampleJson)
+    } catch {
+      setJsonError("Invalid JSON — fix the sample payload and try again.")
+      return
+    }
+
+    setRunning(true)
+    // Slight artificial delay for UX
+    setTimeout(() => {
+      const r = evaluateExpression(expression, payload)
+      setResult(r)
+      setRunning(false)
+    }, 300)
+  }
+
+  const handleReset = () => {
+    setSampleJson(DEFAULT_SAMPLE)
+    setResult(null)
+    setJsonError(null)
+  }
+
+  const passed = result?.conditionResults.filter((r) => r.passed).length ?? 0
+  const failed = result?.conditionResults.filter((r) => !r.passed).length ?? 0
+
+  return (
+    <div
+      className="font-terminal-mono text-[11px] space-y-4"
+      data-testid="filter-expression-tester"
+    >
+      {/* Expression being tested */}
+      <div className="border border-terminal-green/20 bg-terminal-green/3 px-3 py-2 space-y-1">
+        <div className="text-[9px] text-terminal-gray tracking-widest">TESTING_EXPRESSION</div>
+        <div className="text-terminal-cyan text-[10px] break-all leading-relaxed">
+          {serializeExpression(expression) || "(empty)"}
+        </div>
+      </div>
+
+      {/* Sample JSON editor */}
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor="sample-payload-input"
+            className="text-[9px] text-terminal-gray tracking-widest"
+          >
+            SAMPLE_PAYLOAD (JSON)
+          </label>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="text-[9px] text-terminal-gray hover:text-terminal-cyan transition-colors flex items-center gap-1"
+            aria-label="Reset sample payload"
+          >
+            <RotateCcw size={10} /> RESET
+          </button>
+        </div>
+        <textarea
+          id="sample-payload-input"
+          value={sampleJson}
+          onChange={(e) => {
+            setSampleJson(e.target.value)
+            setJsonError(null)
+            setResult(null)
+          }}
+          rows={10}
+          spellCheck={false}
+          className="w-full bg-terminal-black border border-terminal-green/30 text-terminal-green text-[10px] leading-relaxed px-3 py-2 focus:outline-none focus:border-terminal-green resize-none font-terminal-mono placeholder:text-terminal-gray/40 hover:border-terminal-green/50 transition-colors"
+          aria-label="Sample JSON payload"
+          aria-describedby={jsonError ? "json-error-msg" : undefined}
+        />
+        {jsonError && (
+          <p id="json-error-msg" className="text-terminal-danger text-[10px] flex items-center gap-1">
+            <AlertTriangle size={11} /> {jsonError}
+          </p>
+        )}
+      </div>
+
+      {/* Run button */}
+      <button
+        type="button"
+        onClick={handleRun}
+        disabled={running}
+        className="w-full border border-terminal-green text-terminal-green py-2 text-[11px] tracking-widest hover:bg-terminal-green/10 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+        data-testid="run-test-btn"
+      >
+        {running ? (
+          <>
+            <span className="animate-spin inline-block w-3 h-3 border border-terminal-green border-t-transparent rounded-full" />
+            EVALUATING...
+          </>
+        ) : (
+          <>
+            <Play size={12} /> RUN_TEST
+          </>
+        )}
+      </button>
+
+      {/* Results */}
+      {result && (
+        <div className="space-y-3" data-testid="test-results">
+          {/* Overall verdict */}
+          <div
+            className={`flex items-center gap-3 px-4 py-3 border ${
+              result.error
+                ? "border-terminal-yellow/40 bg-terminal-yellow/5"
+                : result.passed
+                  ? "border-terminal-green/50 bg-terminal-green/8"
+                  : "border-terminal-danger/50 bg-terminal-danger/8"
+            }`}
+            data-testid="test-verdict"
+          >
+            {result.error ? (
+              <AlertTriangle size={18} className="text-terminal-yellow flex-shrink-0" />
+            ) : result.passed ? (
+              <CheckCircle2 size={18} className="text-terminal-green flex-shrink-0" />
+            ) : (
+              <XCircle size={18} className="text-terminal-danger flex-shrink-0" />
+            )}
+            <div>
+              <div className={`text-sm font-bold tracking-wider ${result.error ? "text-terminal-yellow" : result.passed ? "text-terminal-green" : "text-terminal-danger"}`}>
+                {result.error ? "EVAL_ERROR" : result.passed ? "FILTER_MATCH — event would be delivered" : "NO_MATCH — event would be dropped"}
+              </div>
+              {!result.error && (
+                <div className="text-[9px] text-terminal-gray mt-0.5">
+                  {passed} passed · {failed} failed · {result.conditionResults.length} total conditions
+                </div>
+              )}
+              {result.error && (
+                <div className="text-[9px] text-terminal-yellow/80 mt-0.5">{result.error}</div>
+              )}
+            </div>
+          </div>
+
+          {/* Per-condition results */}
+          {result.conditionResults.length > 0 && (
+            <div className="space-y-1">
+              <div className="text-[9px] text-terminal-gray tracking-widest px-1">
+                CONDITION_RESULTS
+              </div>
+              {result.conditionResults.map((cr) => (
+                <div
+                  key={cr.conditionId}
+                  className={`flex items-start gap-2 px-3 py-2 border ${
+                    cr.passed ? "border-terminal-green/20 bg-terminal-green/3" : "border-terminal-danger/20 bg-terminal-danger/3"
+                  }`}
+                  data-testid="condition-result-row"
+                >
+                  {cr.passed ? (
+                    <CheckCircle2 size={12} className="text-terminal-green mt-0.5 flex-shrink-0" />
+                  ) : (
+                    <XCircle size={12} className="text-terminal-danger mt-0.5 flex-shrink-0" />
+                  )}
+                  <div className="space-y-0.5 min-w-0">
+                    <div className="text-[10px] text-terminal-cyan font-bold">
+                      {cr.field}
+                      <span className="text-terminal-gray font-normal mx-1">{cr.operator}</span>
+                      <span className="text-terminal-green">{cr.value || "(any)"}</span>
+                    </div>
+                    <div className="text-[9px] text-terminal-gray">
+                      actual: <span className="text-terminal-cyan/80">{JSON.stringify(cr.actual)}</span>
+                    </div>
+                    <div className={`text-[9px] ${cr.passed ? "text-terminal-green/70" : "text-terminal-danger/70"}`}>
+                      {cr.reason}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/soroscan-frontend/components/ui/WebhookFilterExpressionBuilder.tsx
+++ b/soroscan-frontend/components/ui/WebhookFilterExpressionBuilder.tsx
@@ -1,0 +1,651 @@
+"use client"
+
+import * as React from "react"
+import { Plus, Trash2, ChevronDown, ChevronRight, Layers } from "lucide-react"
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type LogicOp = "AND" | "OR"
+export type Operator =
+  | "eq"
+  | "neq"
+  | "contains"
+  | "not_contains"
+  | "starts_with"
+  | "ends_with"
+  | "gt"
+  | "lt"
+  | "gte"
+  | "lte"
+  | "in"
+  | "not_in"
+  | "exists"
+  | "not_exists"
+
+export type FieldType = "string" | "number" | "enum" | "boolean"
+
+export interface FieldDef {
+  key: string
+  label: string
+  type: FieldType
+  /** Only for enum fields */
+  enumValues?: string[]
+}
+
+export interface FilterCondition {
+  id: string
+  kind: "condition"
+  field: string
+  operator: Operator
+  value: string
+}
+
+export interface FilterGroup {
+  id: string
+  kind: "group"
+  logic: LogicOp
+  children: FilterNode[]
+}
+
+export type FilterNode = FilterCondition | FilterGroup
+
+export interface FilterExpression {
+  root: FilterGroup
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+export const WEBHOOK_FIELDS: FieldDef[] = [
+  { key: "event_type",    label: "event_type",    type: "enum", enumValues: ["SWAP_COMPLETE", "LIQUIDITY_ADD", "VAULT_DEPOSIT", "GOV_PROPOSAL", "YIELD_CLAIMED", "ORACLE_UPDATE", "STAKING_LOCK"] },
+  { key: "contract_id",  label: "contract_id",   type: "string" },
+  { key: "amount",       label: "amount",         type: "number" },
+  { key: "ledger",       label: "ledger",         type: "number" },
+  { key: "timestamp",    label: "timestamp",      type: "number" },
+  { key: "from_address", label: "from_address",   type: "string" },
+  { key: "to_address",   label: "to_address",     type: "string" },
+  { key: "asset_code",   label: "asset_code",     type: "string" },
+  { key: "topic",        label: "topic",          type: "string" },
+  { key: "success",      label: "success",        type: "boolean" },
+]
+
+const STRING_OPERATORS: { value: Operator; label: string }[] = [
+  { value: "eq",           label: "=" },
+  { value: "neq",          label: "≠" },
+  { value: "contains",     label: "contains" },
+  { value: "not_contains", label: "not contains" },
+  { value: "starts_with",  label: "starts with" },
+  { value: "ends_with",    label: "ends with" },
+  { value: "in",           label: "in (csv)" },
+  { value: "not_in",       label: "not in (csv)" },
+  { value: "exists",       label: "exists" },
+  { value: "not_exists",   label: "not exists" },
+]
+
+const NUMBER_OPERATORS: { value: Operator; label: string }[] = [
+  { value: "eq",         label: "=" },
+  { value: "neq",        label: "≠" },
+  { value: "gt",         label: ">" },
+  { value: "gte",        label: ">=" },
+  { value: "lt",         label: "<" },
+  { value: "lte",        label: "<=" },
+  { value: "exists",     label: "exists" },
+  { value: "not_exists", label: "not exists" },
+]
+
+const ENUM_OPERATORS: { value: Operator; label: string }[] = [
+  { value: "eq",     label: "=" },
+  { value: "neq",    label: "≠" },
+  { value: "in",     label: "in" },
+  { value: "not_in", label: "not in" },
+]
+
+const BOOLEAN_OPERATORS: { value: Operator; label: string }[] = [
+  { value: "eq", label: "=" },
+]
+
+function getOperatorsForField(field: FieldDef): { value: Operator; label: string }[] {
+  switch (field.type) {
+    case "number":  return NUMBER_OPERATORS
+    case "enum":    return ENUM_OPERATORS
+    case "boolean": return BOOLEAN_OPERATORS
+    default:        return STRING_OPERATORS
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function uid(): string {
+  return Math.random().toString(36).slice(2, 9)
+}
+
+function defaultCondition(): FilterCondition {
+  return {
+    id: uid(),
+    kind: "condition",
+    field: WEBHOOK_FIELDS[0].key,
+    operator: "eq",
+    value: "",
+  }
+}
+
+function defaultGroup(): FilterGroup {
+  return {
+    id: uid(),
+    kind: "group",
+    logic: "AND",
+    children: [defaultCondition()],
+  }
+}
+
+export function emptyExpression(): FilterExpression {
+  return { root: defaultGroup() }
+}
+
+// ── Expression → String serializer ────────────────────────────────────────
+
+const OP_SYMBOLS: Record<Operator, string> = {
+  eq:           "=",
+  neq:          "!=",
+  contains:     "~=",
+  not_contains: "!~=",
+  starts_with:  "^=",
+  ends_with:    "$=",
+  gt:           ">",
+  lt:           "<",
+  gte:          ">=",
+  lte:          "<=",
+  in:           "IN",
+  not_in:       "NOT IN",
+  exists:       "EXISTS",
+  not_exists:   "NOT EXISTS",
+}
+
+function serializeNode(node: FilterNode): string {
+  if (node.kind === "condition") {
+    const op = OP_SYMBOLS[node.operator]
+    if (node.operator === "exists" || node.operator === "not_exists") {
+      return `${op}(${node.field})`
+    }
+    if (node.operator === "in" || node.operator === "not_in") {
+      const vals = node.value.split(",").map((v) => `"${v.trim()}"`).join(", ")
+      return `${node.field} ${op} [${vals}]`
+    }
+    const numFields = WEBHOOK_FIELDS.find((f) => f.key === node.field)
+    const isNum = numFields?.type === "number" || numFields?.type === "boolean"
+    const valStr = isNum ? node.value : `"${node.value}"`
+    return `${node.field} ${op} ${valStr}`
+  }
+  // group
+  if (node.children.length === 0) return "(empty)"
+  const parts = node.children.map(serializeNode)
+  const joined = parts.join(` ${node.logic} `)
+  return node.children.length > 1 ? `(${joined})` : joined
+}
+
+export function serializeExpression(expr: FilterExpression): string {
+  return serializeNode(expr.root)
+}
+
+// ── Immutable tree update helpers ──────────────────────────────────────────
+
+function updateNodeInGroup(group: FilterGroup, targetId: string, updater: (node: FilterNode) => FilterNode): FilterGroup {
+  return {
+    ...group,
+    children: group.children.map((child) => {
+      if (child.id === targetId) return updater(child)
+      if (child.kind === "group") return updateNodeInGroup(child, targetId, updater)
+      return child
+    }),
+  }
+}
+
+function removeNodeFromGroup(group: FilterGroup, targetId: string): FilterGroup {
+  return {
+    ...group,
+    children: group.children
+      .filter((child) => child.id !== targetId)
+      .map((child) => (child.kind === "group" ? removeNodeFromGroup(child, targetId) : child)),
+  }
+}
+
+function addNodeToGroup(group: FilterGroup, targetGroupId: string, node: FilterNode): FilterGroup {
+  if (group.id === targetGroupId) {
+    return { ...group, children: [...group.children, node] }
+  }
+  return {
+    ...group,
+    children: group.children.map((child) =>
+      child.kind === "group" ? addNodeToGroup(child, targetGroupId, node) : child
+    ),
+  }
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+interface ConditionRowProps {
+  condition: FilterCondition
+  depth: number
+  isOnly: boolean
+  onUpdate: (id: string, patch: Partial<FilterCondition>) => void
+  onRemove: (id: string) => void
+}
+
+function ConditionRow({ condition, depth, isOnly, onUpdate, onRemove }: ConditionRowProps) {
+  const fieldDef = WEBHOOK_FIELDS.find((f) => f.key === condition.field) ?? WEBHOOK_FIELDS[0]
+  const operators = getOperatorsForField(fieldDef)
+  const noValue = condition.operator === "exists" || condition.operator === "not_exists"
+  const isEnum = fieldDef.type === "enum" && (condition.operator === "eq" || condition.operator === "neq")
+  const isBool = fieldDef.type === "boolean"
+  const isInOp = condition.operator === "in" || condition.operator === "not_in"
+
+  const handleFieldChange = (newField: string) => {
+    const newDef = WEBHOOK_FIELDS.find((f) => f.key === newField) ?? WEBHOOK_FIELDS[0]
+    const newOps = getOperatorsForField(newDef)
+    const validOp = newOps.find((o) => o.value === condition.operator) ? condition.operator : newOps[0].value
+    onUpdate(condition.id, { field: newField, operator: validOp as Operator, value: "" })
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 py-1.5 px-2 border border-terminal-green/10 hover:border-terminal-green/30 transition-colors group/row"
+      data-testid="webhook-filter-condition"
+      style={{ marginLeft: `${depth * 8}px` }}
+    >
+      {/* Field select */}
+      <select
+        value={condition.field}
+        onChange={(e) => handleFieldChange(e.target.value)}
+        aria-label="Filter field"
+        className="bg-terminal-black border border-terminal-green/40 text-terminal-green text-[11px] px-2 py-1 focus:outline-none focus:border-terminal-green cursor-pointer hover:border-terminal-green/70 transition-colors"
+      >
+        {WEBHOOK_FIELDS.map((f) => (
+          <option key={f.key} value={f.key} className="bg-[#0a0e27]">
+            {f.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Operator select */}
+      <select
+        value={condition.operator}
+        onChange={(e) => onUpdate(condition.id, { operator: e.target.value as Operator, value: "" })}
+        aria-label="Filter operator"
+        className="bg-terminal-black border border-terminal-cyan/40 text-terminal-cyan text-[11px] px-2 py-1 focus:outline-none focus:border-terminal-cyan cursor-pointer hover:border-terminal-cyan/70 transition-colors"
+      >
+        {operators.map((op) => (
+          <option key={op.value} value={op.value} className="bg-[#0a0e27]">
+            {op.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Value input */}
+      {!noValue && (
+        <>
+          {isEnum ? (
+            <select
+              value={condition.value}
+              onChange={(e) => onUpdate(condition.id, { value: e.target.value })}
+              aria-label="Filter value"
+              className="bg-terminal-black border border-terminal-green/40 text-terminal-green text-[11px] px-2 py-1 focus:outline-none focus:border-terminal-green cursor-pointer hover:border-terminal-green/70 transition-colors"
+            >
+              <option value="" className="bg-[#0a0e27] text-terminal-gray">
+                select...
+              </option>
+              {fieldDef.enumValues?.map((v) => (
+                <option key={v} value={v} className="bg-[#0a0e27]">
+                  {v}
+                </option>
+              ))}
+            </select>
+          ) : isBool ? (
+            <select
+              value={condition.value}
+              onChange={(e) => onUpdate(condition.id, { value: e.target.value })}
+              aria-label="Filter value"
+              className="bg-terminal-black border border-terminal-green/40 text-terminal-green text-[11px] px-2 py-1 focus:outline-none focus:border-terminal-green cursor-pointer hover:border-terminal-green/70 transition-colors"
+            >
+              <option value="true" className="bg-[#0a0e27]">true</option>
+              <option value="false" className="bg-[#0a0e27]">false</option>
+            </select>
+          ) : (
+            <input
+              type={fieldDef.type === "number" ? "number" : "text"}
+              value={condition.value}
+              onChange={(e) => onUpdate(condition.id, { value: e.target.value })}
+              placeholder={isInOp ? "val1, val2, val3" : "value"}
+              aria-label="Filter value"
+              className="bg-terminal-black border border-terminal-green/40 text-terminal-green text-[11px] px-2 py-1 focus:outline-none focus:border-terminal-green min-w-[100px] placeholder:text-terminal-gray/50 hover:border-terminal-green/70 transition-colors"
+            />
+          )}
+        </>
+      )}
+
+      {/* Type badge */}
+      <span className="text-[9px] px-1 border border-terminal-gray/20 text-terminal-gray/60 uppercase">
+        {fieldDef.type}
+      </span>
+
+      {/* Remove button */}
+      {!isOnly && (
+        <button
+          type="button"
+          onClick={() => onRemove(condition.id)}
+          aria-label="Remove condition"
+          className="ml-auto opacity-0 group-hover/row:opacity-100 transition-opacity text-terminal-danger hover:text-terminal-danger/80 p-0.5"
+          data-testid="remove-condition-btn"
+        >
+          <Trash2 size={12} />
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ── Group component (recursive) ────────────────────────────────────────────
+
+interface FilterGroupNodeProps {
+  group: FilterGroup
+  depth: number
+  isRoot: boolean
+  onUpdate: (groupId: string, logic: LogicOp) => void
+  onUpdateCondition: (id: string, patch: Partial<FilterCondition>) => void
+  onRemoveNode: (id: string) => void
+  onAddCondition: (groupId: string) => void
+  onAddSubGroup: (groupId: string) => void
+  totalNodes: number
+}
+
+function FilterGroupNode({
+  group,
+  depth,
+  isRoot,
+  onUpdate,
+  onUpdateCondition,
+  onRemoveNode,
+  onAddCondition,
+  onAddSubGroup,
+  totalNodes,
+}: FilterGroupNodeProps) {
+  const [collapsed, setCollapsed] = React.useState(false)
+  const depthColors = ["border-terminal-green/30", "border-terminal-cyan/30", "border-[#a855f7]/30", "border-terminal-warning/30"]
+  const depthAccent = ["text-terminal-green", "text-terminal-cyan", "text-[#a855f7]", "text-terminal-warning"]
+  const borderColor = depthColors[depth % depthColors.length]
+  const accent = depthAccent[depth % depthAccent.length]
+
+  return (
+    <div
+      className={`border ${borderColor} ${depth > 0 ? "ml-4" : ""}`}
+      data-testid={isRoot ? "webhook-filter-root-group" : "webhook-filter-sub-group"}
+    >
+      {/* Group header */}
+      <div className={`flex items-center gap-2 px-3 py-1.5 border-b ${borderColor} bg-terminal-green/3`}>
+        {!isRoot && (
+          <button
+            type="button"
+            onClick={() => setCollapsed((c) => !c)}
+            className={`${accent} hover:opacity-70 transition-opacity`}
+            aria-label={collapsed ? "Expand group" : "Collapse group"}
+          >
+            {collapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
+          </button>
+        )}
+
+        <span className={`text-[9px] tracking-widest ${accent}`}>
+          {isRoot ? "[ROOT]" : `[GROUP_${depth}]`}
+        </span>
+
+        <span className="text-[9px] text-terminal-gray">MATCH</span>
+
+        {(["AND", "OR"] as LogicOp[]).map((op) => (
+          <button
+            key={op}
+            type="button"
+            onClick={() => onUpdate(group.id, op)}
+            aria-pressed={group.logic === op}
+            data-testid={`logic-${op.toLowerCase()}-btn`}
+            className={`text-[10px] px-2 py-0.5 border transition-all ${
+              group.logic === op
+                ? `border-current ${accent} bg-current/10`
+                : "border-terminal-gray/30 text-terminal-gray hover:border-terminal-gray/60"
+            }`}
+          >
+            {op}
+          </button>
+        ))}
+
+        <span className={`text-[9px] text-terminal-gray ml-1`}>
+          {group.children.length} rule{group.children.length !== 1 ? "s" : ""}
+        </span>
+
+        {/* Group actions */}
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onAddCondition(group.id)}
+            className="text-[9px] px-2 py-0.5 border border-terminal-green/30 text-terminal-green hover:border-terminal-green hover:bg-terminal-green/5 transition-colors flex items-center gap-1"
+            data-testid="add-condition-btn"
+          >
+            <Plus size={10} /> CONDITION
+          </button>
+          <button
+            type="button"
+            onClick={() => onAddSubGroup(group.id)}
+            className="text-[9px] px-2 py-0.5 border border-terminal-cyan/30 text-terminal-cyan hover:border-terminal-cyan hover:bg-terminal-cyan/5 transition-colors flex items-center gap-1"
+            data-testid="add-group-btn"
+          >
+            <Layers size={10} /> GROUP
+          </button>
+          {!isRoot && totalNodes > 1 && (
+            <button
+              type="button"
+              onClick={() => onRemoveNode(group.id)}
+              aria-label="Remove group"
+              className="text-terminal-danger hover:text-terminal-danger/70 transition-colors p-0.5"
+              data-testid="remove-group-btn"
+            >
+              <Trash2 size={11} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Group children */}
+      {!collapsed && (
+        <div className="p-2 space-y-1.5">
+          {group.children.length === 0 ? (
+            <div className="text-[10px] text-terminal-gray/50 text-center py-2">
+              No conditions — add one above
+            </div>
+          ) : (
+            group.children.map((child, idx) => (
+              <div key={child.id}>
+                {idx > 0 && (
+                  <div className={`text-[9px] ${accent} px-2 py-0.5 my-1 font-bold`}>
+                    {group.logic}
+                  </div>
+                )}
+                {child.kind === "condition" ? (
+                  <ConditionRow
+                    condition={child}
+                    depth={depth}
+                    isOnly={group.children.length === 1 && isRoot}
+                    onUpdate={onUpdateCondition}
+                    onRemove={onRemoveNode}
+                  />
+                ) : (
+                  <FilterGroupNode
+                    group={child}
+                    depth={depth + 1}
+                    isRoot={false}
+                    onUpdate={onUpdate}
+                    onUpdateCondition={onUpdateCondition}
+                    onRemoveNode={onRemoveNode}
+                    onAddCondition={onAddCondition}
+                    onAddSubGroup={onAddSubGroup}
+                    totalNodes={totalNodes}
+                  />
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main Component ─────────────────────────────────────────────────────────
+
+export interface WebhookFilterExpressionBuilderProps {
+  value?: FilterExpression
+  onChange: (expr: FilterExpression) => void
+  /** Called when user explicitly applies/saves */
+  onApply?: (expr: FilterExpression, serialized: string) => void
+  className?: string
+}
+
+export function WebhookFilterExpressionBuilder({
+  value,
+  onChange,
+  onApply,
+  className = "",
+}: WebhookFilterExpressionBuilderProps) {
+  const [expr, setExpr] = React.useState<FilterExpression>(value ?? emptyExpression())
+  const [previewExpanded, setPreviewExpanded] = React.useState(true)
+
+  // Sync with external value
+  React.useEffect(() => {
+    if (value) setExpr(value)
+  }, [value])
+
+  const update = (next: FilterExpression) => {
+    setExpr(next)
+    onChange(next)
+  }
+
+  const serialized = React.useMemo(() => serializeExpression(expr), [expr])
+
+  const countNodes = (group: FilterGroup): number => {
+    return group.children.reduce((acc, child) => {
+      if (child.kind === "group") return acc + countNodes(child)
+      return acc + 1
+    }, 0)
+  }
+
+  // ── Mutation handlers ──────────────────────────────────────────────────
+
+  const handleUpdateGroupLogic = (groupId: string, logic: LogicOp) => {
+    const updatedRoot = updateNodeInGroup(expr.root, groupId, (node) => {
+      if (node.kind === "group") return { ...node, logic }
+      return node
+    }) as FilterGroup
+    // Special case: root itself
+    const newRoot = expr.root.id === groupId ? { ...expr.root, logic } : updatedRoot
+    update({ root: newRoot })
+  }
+
+  const handleUpdateCondition = (id: string, patch: Partial<FilterCondition>) => {
+    const newRoot = updateNodeInGroup(expr.root, id, (node) => {
+      if (node.kind === "condition") return { ...node, ...patch }
+      return node
+    }) as FilterGroup
+    update({ root: newRoot })
+  }
+
+  const handleRemoveNode = (id: string) => {
+    const newRoot = removeNodeFromGroup(expr.root, id)
+    update({ root: newRoot })
+  }
+
+  const handleAddCondition = (groupId: string) => {
+    const cond = defaultCondition()
+    const newRoot = addNodeToGroup(expr.root, groupId, cond)
+    update({ root: newRoot })
+  }
+
+  const handleAddSubGroup = (groupId: string) => {
+    const subGroup = defaultGroup()
+    const newRoot = addNodeToGroup(expr.root, groupId, subGroup)
+    update({ root: newRoot })
+  }
+
+  const handleReset = () => {
+    const fresh = emptyExpression()
+    update(fresh)
+  }
+
+  const totalNodes = countNodes(expr.root)
+
+  return (
+    <div
+      className={`font-terminal-mono text-[11px] space-y-2 ${className}`}
+      role="group"
+      aria-label="Webhook filter expression builder"
+    >
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-1">
+        <span className="text-[9px] text-terminal-gray tracking-widest">
+          {totalNodes} rule{totalNodes !== 1 ? "s" : ""} defined
+        </span>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="text-[9px] px-2 py-0.5 border border-terminal-danger/30 text-terminal-danger hover:border-terminal-danger hover:bg-terminal-danger/5 transition-colors"
+            data-testid="reset-expression-btn"
+          >
+            RESET
+          </button>
+          {onApply && (
+            <button
+              type="button"
+              onClick={() => onApply(expr, serialized)}
+              className="text-[9px] px-2 py-0.5 border border-terminal-green/60 text-terminal-green hover:bg-terminal-green/10 transition-colors"
+              data-testid="apply-expression-btn"
+            >
+              APPLY_FILTER
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Recursive tree */}
+      <FilterGroupNode
+        group={expr.root}
+        depth={0}
+        isRoot={true}
+        onUpdate={handleUpdateGroupLogic}
+        onUpdateCondition={handleUpdateCondition}
+        onRemoveNode={handleRemoveNode}
+        onAddCondition={handleAddCondition}
+        onAddSubGroup={handleAddSubGroup}
+        totalNodes={totalNodes}
+      />
+
+      {/* Expression preview */}
+      <div className="border border-terminal-green/20 bg-terminal-green/3">
+        <button
+          type="button"
+          onClick={() => setPreviewExpanded((p) => !p)}
+          className="w-full flex items-center justify-between px-3 py-1.5 text-[9px] text-terminal-gray hover:text-terminal-green transition-colors"
+          aria-expanded={previewExpanded}
+          aria-controls="filter-expression-preview"
+        >
+          <span className="tracking-widest">EXPRESSION_PREVIEW</span>
+          {previewExpanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+        </button>
+        {previewExpanded && (
+          <div
+            id="filter-expression-preview"
+            className="px-3 py-2 border-t border-terminal-green/10 text-terminal-cyan text-[10px] break-all leading-relaxed"
+            data-testid="filter-expression-preview"
+            aria-live="polite"
+          >
+            {serialized || "(empty expression)"}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Add WebhookFilterExpressionBuilder with recursive AND/OR group nesting
- Add FilterExpressionTester for real-time pass/fail evaluation against sample JSON
- Add FilterBuilderModal combining builder + tester in a tabbed modal
- Update CreateWebhookModal to integrate filter expression builder flow
- Add standalone filter builder page at /webhooks/filter-builder
- Add optional filterExpression field to Webhook type
- Add 61 tests covering serializer, evaluator engine, and all UI interactions

Closes #578