### PR TITLE
Feat: add responsive mobile card grid for events

### DIFF
--- a/soroscan-frontend/__tests__/event-table-responsive.test.tsx
+++ b/soroscan-frontend/__tests__/event-table-responsive.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EventTable } from "@/app/dashboard/components/EventTable";
+import type { EventRecord } from "@/components/ingest/types";
+
+const mockEvents: EventRecord[] = [
+  {
+    id: "event-1",
+    contractId: "CCAAA123",
+    contractName: "Test Contract",
+    eventType: "transfer",
+    ledger: 1000,
+    eventIndex: 0,
+    timestamp: "2024-01-01T00:00:00Z",
+    txHash: "abc123",
+    payload: { amount: 100 },
+  },
+  {
+    id: "event-2",
+    contractId: "CCBBB456",
+    contractName: "Another Contract",
+    eventType: "swap",
+    ledger: 1001,
+    eventIndex: 1,
+    timestamp: "2024-01-01T01:00:00Z",
+    txHash: "def456",
+    payload: { from: "A", to: "B" },
+  },
+];
+
+describe("EventTable responsive card grid", () => {
+  it("renders the mobile card grid container", () => {
+    render(
+      <EventTable
+        events={mockEvents}
+        loading={false}
+        onEventClick={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("events-card-grid")).toBeInTheDocument();
+    expect(screen.getAllByTestId("event-card")).toHaveLength(2);
+  });
+
+  it("shows event information inside the mobile cards", () => {
+    render(
+      <EventTable
+        events={mockEvents}
+        loading={false}
+        onEventClick={jest.fn()}
+      />,
+    );
+
+    const cards = screen.getAllByTestId("event-card");
+
+    expect(cards[0]).toHaveTextContent("transfer");
+    expect(cards[0]).toHaveTextContent("CCAAA123");
+    expect(cards[0]).toHaveTextContent("1000");
+    expect(cards[0]).toHaveTextContent("abc123");
+
+    expect(cards[1]).toHaveTextContent("swap");
+    expect(cards[1]).toHaveTextContent("CCBBB456");
+    expect(cards[1]).toHaveTextContent("1001");
+    expect(cards[1]).toHaveTextContent("def456");
+  });
+
+  it("calls onEventClick when a mobile card is clicked", () => {
+    const handleEventClick = jest.fn();
+
+    render(
+      <EventTable
+        events={mockEvents}
+        loading={false}
+        onEventClick={handleEventClick}
+      />,
+    );
+
+    const cards = screen.getAllByTestId("event-card");
+    fireEvent.click(cards[0]);
+
+    expect(handleEventClick).toHaveBeenCalledWith(mockEvents[0]);
+  });
+
+  it("calls onEventClick when a mobile card is opened with keyboard", () => {
+    const handleEventClick = jest.fn();
+
+    render(
+      <EventTable
+        events={mockEvents}
+        loading={false}
+        onEventClick={handleEventClick}
+      />,
+    );
+
+    const cards = screen.getAllByTestId("event-card");
+    fireEvent.keyDown(cards[0], { key: "Enter" });
+
+    expect(handleEventClick).toHaveBeenCalledWith(mockEvents[0]);
+  });
+
+  it("shows skeleton rows while loading", () => {
+    const { container } = render(
+      <EventTable events={[]} loading={true} onEventClick={jest.fn()} />,
+    );
+
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(5);
+    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no events are available", () => {
+    render(<EventTable events={[]} loading={false} onEventClick={jest.fn()} />);
+
+    expect(screen.getByText(/No events found/i)).toBeInTheDocument();
+  });
+});

--- a/soroscan-frontend/app/dashboard/components/EventTable.tsx
+++ b/soroscan-frontend/app/dashboard/components/EventTable.tsx
@@ -9,10 +9,10 @@ interface EventTableProps {
   events: EventRecord[];
   loading: boolean;
   onEventClick: (event: EventRecord) => void;
-  eventTags: Record<string, string[]>;
-  tagSuggestions: string[];
-  onAddTag: (eventId: string, tag: string) => void;
-  onRemoveTag: (eventId: string, tag: string) => void;
+  eventTags?: Record<string, string[]>;
+  tagSuggestions?: string[];
+  onAddTag?: (eventId: string, tag: string) => void;
+  onRemoveTag?: (eventId: string, tag: string) => void;
   hasActiveFilters?: boolean;
   onClearFilters?: () => void;
   showTags?: boolean;
@@ -26,7 +26,7 @@ export function EventTable({
   tagSuggestions = [],
   onAddTag = () => {},
   onRemoveTag = () => {},
-  hasActiveFilters,
+  hasActiveFilters = false,
   onClearFilters,
   showTags = false,
 }: EventTableProps) {
@@ -44,15 +44,114 @@ export function EventTable({
   };
 
   const getEventTypeColor = (eventType: string): string => {
-    const hash = eventType.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    const hash = eventType
+      .split("")
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+
     const colors = [
       "rgba(0, 255, 156, 0.8)",
       "rgba(0, 212, 255, 0.8)",
       "rgba(255, 170, 0, 0.8)",
       "rgba(255, 102, 255, 0.8)",
     ];
+
     return colors[hash % colors.length];
   };
+
+  const handleCardKeyDown = (
+    event: React.KeyboardEvent<HTMLElement>,
+    record: EventRecord,
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onEventClick(record);
+    }
+  };
+
+  const renderTags = (event: EventRecord) => (
+    <div style={{ display: "grid", gap: "0.4rem" }}>
+      <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
+        {(eventTags[event.id] ?? []).map((tag) => (
+          <span
+            key={tag}
+            className={styles.pill}
+            style={{ fontSize: "0.72rem", padding: "0.2rem 0.45rem" }}
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={(clickEvent) => {
+                clickEvent.stopPropagation();
+                onRemoveTag(event.id, tag);
+              }}
+              style={{
+                background: "transparent",
+                border: 0,
+                color: "inherit",
+                cursor: "pointer",
+                marginLeft: "0.3rem",
+                padding: 0,
+              }}
+              title={`Remove ${tag}`}
+            >
+              x
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: "0.35rem" }}>
+        <input
+          className={styles.fieldInput}
+          list={`event-tag-suggestions-${event.id}`}
+          value={tagInputs[event.id] ?? ""}
+          placeholder="add tag"
+          onClick={(clickEvent) => clickEvent.stopPropagation()}
+          onChange={(changeEvent) => {
+            const value = changeEvent.target.value;
+            setTagInputs((prev) => ({ ...prev, [event.id]: value }));
+          }}
+          onKeyDown={(keyEvent) => {
+            if (keyEvent.key === "Enter") {
+              keyEvent.preventDefault();
+              keyEvent.stopPropagation();
+
+              const value = tagInputs[event.id] ?? "";
+              onAddTag(event.id, value);
+              setTagInputs((prev) => ({ ...prev, [event.id]: "" }));
+            }
+          }}
+          style={{ padding: "0.35rem 0.45rem", fontSize: "0.75rem" }}
+        />
+
+        <button
+          type="button"
+          className={styles.btn}
+          style={{
+            padding: "0.2rem 0.5rem",
+            fontSize: "0.75rem",
+            minWidth: "auto",
+          }}
+          onClick={(clickEvent) => {
+            clickEvent.stopPropagation();
+
+            const value = tagInputs[event.id] ?? "";
+            onAddTag(event.id, value);
+            setTagInputs((prev) => ({ ...prev, [event.id]: "" }));
+          }}
+          title="Add tag"
+        >
+          +
+        </button>
+      </div>
+
+      <datalist id={`event-tag-suggestions-${event.id}`}>
+        {tagSuggestions.map((tag) => (
+          <option key={tag} value={tag} />
+        ))}
+      </datalist>
+    </div>
+  );
 
   if (loading) {
     return (
@@ -73,27 +172,52 @@ export function EventTable({
             {[...Array(5)].map((_, index) => (
               <tr key={`skeleton-${index}`}>
                 <td data-label="Contract">
-                  <div className={styles.skeleton} style={{ width: "120px", height: "20px" }} />
+                  <div
+                    className={styles.skeleton}
+                    style={{ width: "120px", height: "20px" }}
+                  />
                 </td>
                 <td data-label="Type">
-                  <div className={styles.skeleton} style={{ width: "80px", height: "24px", borderRadius: "12px" }} />
+                  <div
+                    className={styles.skeleton}
+                    style={{
+                      width: "80px",
+                      height: "24px",
+                      borderRadius: "12px",
+                    }}
+                  />
                 </td>
                 <td data-label="Ledger">
-                  <div className={styles.skeleton} style={{ width: "60px", height: "24px" }} />
+                  <div
+                    className={styles.skeleton}
+                    style={{ width: "60px", height: "24px" }}
+                  />
                 </td>
                 <td data-label="Time">
-                  <div className={styles.skeleton} style={{ width: "140px", height: "20px" }} />
+                  <div
+                    className={styles.skeleton}
+                    style={{ width: "140px", height: "20px" }}
+                  />
                 </td>
                 <td data-label="Tx">
-                  <div className={styles.skeleton} style={{ width: "100px", height: "20px" }} />
+                  <div
+                    className={styles.skeleton}
+                    style={{ width: "100px", height: "20px" }}
+                  />
                 </td>
                 {showTags && (
                   <td data-label="Tags">
-                    <div className={styles.skeleton} style={{ width: "120px", height: "24px" }} />
+                    <div
+                      className={styles.skeleton}
+                      style={{ width: "120px", height: "24px" }}
+                    />
                   </td>
                 )}
                 <td data-label="Actions">
-                  <div className={styles.skeleton} style={{ width: "50px", height: "28px" }} />
+                  <div
+                    className={styles.skeleton}
+                    style={{ width: "50px", height: "28px" }}
+                  />
                 </td>
               </tr>
             ))}
@@ -103,9 +227,154 @@ export function EventTable({
     );
   }
 
+  if (!events.length) {
+    return (
+      <div className={styles.tableWrap}>
+        <div className={styles.emptyTable}>
+          {hasActiveFilters ? (
+            <div
+              style={{
+                padding: "3rem 1rem",
+                textAlign: "center",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "1rem",
+              }}
+            >
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: "1.25rem",
+                  color: "var(--text-primary)",
+                }}
+              >
+                No events match your criteria
+              </h3>
+              <p
+                style={{
+                  margin: 0,
+                  color: "var(--text-secondary)",
+                  maxWidth: "400px",
+                  lineHeight: 1.5,
+                }}
+              >
+                We couldn&apos;t find any events matching your current search
+                and filter settings. Try adjusting them or clear all filters to
+                see more results.
+              </p>
+              {onClearFilters && (
+                <button
+                  type="button"
+                  className={styles.btn}
+                  style={{ marginTop: "1rem" }}
+                  onClick={onClearFilters}
+                >
+                  Clear Filters
+                </button>
+              )}
+            </div>
+          ) : (
+            "No events found. Select a contract and adjust filters to view events."
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.tableWrap}>
-      <table className={styles.eventTable}>
+      <style>
+        {`
+          .soroscan-events-card-grid {
+            display: none;
+          }
+
+          .soroscan-event-card {
+            width: 100%;
+            text-align: left;
+            background: rgba(13, 21, 34, 0.92);
+            border: 1px solid rgba(0, 212, 255, 0.25);
+            border-radius: 10px;
+            padding: 1rem;
+            color: #d6f7ff;
+            cursor: pointer;
+            transition:
+              border-color 0.2s ease,
+              box-shadow 0.2s ease,
+              transform 0.2s ease;
+          }
+
+          .soroscan-event-card:hover,
+          .soroscan-event-card:focus {
+            outline: none;
+            border-color: rgba(0, 212, 255, 0.75);
+            box-shadow: 0 0 18px rgba(0, 212, 255, 0.18);
+            transform: translateY(-1px);
+          }
+
+          .soroscan-event-card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 0.75rem;
+            margin-bottom: 0.85rem;
+          }
+
+          .soroscan-event-card-title {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+          }
+
+          .soroscan-event-card-label {
+            font-size: 0.7rem;
+            color: #7ba8b5;
+            text-transform: uppercase;
+            letter-spacing: 0.05rem;
+          }
+
+          .soroscan-event-card-grid-inner {
+            display: grid;
+            gap: 0.75rem;
+          }
+
+          .soroscan-event-card-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.75rem;
+            border-top: 1px solid rgba(123, 168, 181, 0.14);
+            padding-top: 0.65rem;
+          }
+
+          .soroscan-event-card-value {
+            color: #d6f7ff;
+            text-align: right;
+            word-break: break-word;
+          }
+
+          .soroscan-event-card-footer {
+            margin-top: 1rem;
+            color: #00ff9c;
+            font-size: 0.78rem;
+            text-align: right;
+          }
+
+          @media (max-width: 768px) {
+            .soroscan-events-table {
+              display: none;
+            }
+
+            .soroscan-events-card-grid {
+              display: grid;
+              grid-template-columns: 1fr;
+              gap: 0.9rem;
+            }
+          }
+        `}
+      </style>
+
+      <table className={`${styles.eventTable} soroscan-events-table`}>
         <thead>
           <tr>
             <th>Contract</th>
@@ -118,215 +387,207 @@ export function EventTable({
           </tr>
         </thead>
         <tbody>
-          {!events.length ? (
-            <tr>
-              <td colSpan={showTags ? 7 : 6} className={styles.emptyTable}>
-                {loading ? (
-                  "Loading events..."
-                ) : hasActiveFilters ? (
-                  <div style={{ padding: "3rem 1rem", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: "1rem" }}>
-                    <div style={{ color: "var(--text-secondary)", marginBottom: "0.5rem" }}>
-                      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                        <circle cx="11" cy="11" r="8"></circle>
-                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-                      </svg>
-                    </div>
-                    <h3 style={{ margin: 0, fontSize: "1.25rem", color: "var(--text-primary)" }}>
-                      No events match your criteria
-                    </h3>
-                    <p style={{ margin: 0, color: "var(--text-secondary)", maxWidth: "400px", lineHeight: 1.5 }}>
-                      We couldn&apos;t find any events matching your current search and filter settings. Try adjusting them or clear all filters to see more results.
-                    </p>
-                    <button
-                      type="button"
-                      className={styles.btn}
-                      style={{ marginTop: "1rem" }}
-                      onClick={onClearFilters}
-                    >
-                      Clear Filters
-                    </button>
-                  </div>
-                ) : (
-                  "No events found. Select a contract and adjust filters to view events."
-                )}
+          {events.map((event) => (
+            <tr
+              key={event.id}
+              style={{
+                cursor: "pointer",
+                transition: "all 0.2s ease",
+              }}
+              onClick={() => onEventClick(event)}
+              onMouseEnter={(mouseEvent) => {
+                mouseEvent.currentTarget.style.boxShadow = `0 0 15px ${getEventTypeColor(
+                  event.eventType,
+                )}`;
+              }}
+              onMouseLeave={(mouseEvent) => {
+                mouseEvent.currentTarget.style.boxShadow = "none";
+              }}
+            >
+              <td data-label="Contract">
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.5rem",
+                  }}
+                >
+                  <code>{shortHash(event.contractId)}</code>
+                  <button
+                    type="button"
+                    className={styles.btn}
+                    style={{
+                      padding: "0.2rem 0.4rem",
+                      fontSize: "0.7rem",
+                      minWidth: "auto",
+                    }}
+                    onClick={(clickEvent) => {
+                      clickEvent.stopPropagation();
+                      void copyToClipboard(
+                        event.contractId,
+                        `contract-${event.id}`,
+                      );
+                    }}
+                    title="Copy contract ID"
+                  >
+                    {copiedId === `contract-${event.id}` ? "✓" : "📋"}
+                  </button>
+                </div>
+              </td>
+
+              <td data-label="Type">
+                <span
+                  className={styles.pill}
+                  style={{
+                    borderColor: getEventTypeColor(event.eventType),
+                    backgroundColor: `${getEventTypeColor(event.eventType)}15`,
+                    color: getEventTypeColor(event.eventType),
+                  }}
+                >
+                  {event.eventType}
+                </span>
+              </td>
+
+              <td data-label="Ledger">
+                <button
+                  type="button"
+                  className={styles.btn}
+                  style={{
+                    padding: "0.2rem 0.5rem",
+                    fontSize: "0.75rem",
+                  }}
+                  onClick={(clickEvent) => {
+                    clickEvent.stopPropagation();
+                  }}
+                >
+                  {event.ledger}
+                </button>
+              </td>
+
+              <td data-label="Time">{formatDateTime(event.timestamp)}</td>
+
+              <td data-label="Tx">
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.5rem",
+                  }}
+                >
+                  <code>{shortHash(event.txHash)}</code>
+                  <button
+                    type="button"
+                    className={styles.btn}
+                    style={{
+                      padding: "0.2rem 0.4rem",
+                      fontSize: "0.7rem",
+                      minWidth: "auto",
+                    }}
+                    onClick={(clickEvent) => {
+                      clickEvent.stopPropagation();
+                      void copyToClipboard(event.txHash, `tx-${event.id}`);
+                    }}
+                    title="Copy transaction hash"
+                  >
+                    {copiedId === `tx-${event.id}` ? "✓" : "📋"}
+                  </button>
+                </div>
+              </td>
+
+              {showTags && <td data-label="Tags">{renderTags(event)}</td>}
+
+              <td data-label="Actions">
+                <button
+                  type="button"
+                  className={styles.btn}
+                  style={{
+                    padding: "0.3rem 0.6rem",
+                    fontSize: "0.75rem",
+                  }}
+                  onClick={(clickEvent) => {
+                    clickEvent.stopPropagation();
+                    onEventClick(event);
+                  }}
+                >
+                  View
+                </button>
               </td>
             </tr>
-          ) : (
-            events.map((event) => (
-              <tr
-                key={event.id}
-                style={{
-                  cursor: "pointer",
-                  transition: "all 0.2s ease",
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 15px ${getEventTypeColor(event.eventType)}`;
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.boxShadow = "none";
-                }}
-              >
-                <td data-label="Contract">
-                  <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-                    <code>{shortHash(event.contractId)}</code>
-                    <button
-                      type="button"
-                      className={styles.btn}
-                      style={{
-                        padding: "0.2rem 0.4rem",
-                        fontSize: "0.7rem",
-                        minWidth: "auto",
-                      }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        copyToClipboard(event.contractId, `contract-${event.id}`);
-                      }}
-                      title="Copy contract ID"
-                    >
-                      {copiedId === `contract-${event.id}` ? "✓" : "📋"}
-                    </button>
-                  </div>
-                </td>
-                <td data-label="Type">
-                  <span
-                    className={styles.pill}
-                    style={{
-                      borderColor: getEventTypeColor(event.eventType),
-                      backgroundColor: `${getEventTypeColor(event.eventType)}15`,
-                      color: getEventTypeColor(event.eventType),
-                    }}
-                  >
-                    {event.eventType}
-                  </span>
-                </td>
-                <td data-label="Ledger">
-                  <button
-                    type="button"
-                    className={styles.btn}
-                    style={{
-                      padding: "0.2rem 0.5rem",
-                      fontSize: "0.75rem",
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                    }}
-                  >
-                    {event.ledger}
-                  </button>
-                </td>
-                <td data-label="Time">{formatDateTime(event.timestamp)}</td>
-                <td data-label="Tx">
-                  <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-                    <code>{shortHash(event.txHash)}</code>
-                    <button
-                      type="button"
-                      className={styles.btn}
-                      style={{
-                        padding: "0.2rem 0.4rem",
-                        fontSize: "0.7rem",
-                        minWidth: "auto",
-                      }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        copyToClipboard(event.txHash, `tx-${event.id}`);
-                      }}
-                      title="Copy transaction hash"
-                    >
-                      {copiedId === `tx-${event.id}` ? "✓" : "📋"}
-                    </button>
-                  </div>
-                </td>
-                {showTags && (
-                  <td data-label="Tags">
-                    <div style={{ display: "grid", gap: "0.4rem" }}>
-                      <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
-                        {(eventTags[event.id] ?? []).map((tag) => (
-                          <span key={tag} className={styles.pill} style={{ fontSize: "0.72rem", padding: "0.2rem 0.45rem" }}>
-                            {tag}
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onRemoveTag(event.id, tag);
-                              }}
-                              style={{
-                                background: "transparent",
-                                border: 0,
-                                color: "inherit",
-                                cursor: "pointer",
-                                marginLeft: "0.3rem",
-                                padding: 0,
-                              }}
-                              title={`Remove ${tag}`}
-                            >
-                              x
-                            </button>
-                          </span>
-                        ))}
-                      </div>
-                      <div style={{ display: "flex", gap: "0.35rem" }}>
-                        <input
-                          className={styles.fieldInput}
-                          list={`event-tag-suggestions-${event.id}`}
-                          value={tagInputs[event.id] ?? ""}
-                          placeholder="add tag"
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) => {
-                            const value = e.target.value;
-                            setTagInputs((prev) => ({ ...prev, [event.id]: value }));
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              const value = tagInputs[event.id] ?? "";
-                              onAddTag(event.id, value);
-                              setTagInputs((prev) => ({ ...prev, [event.id]: "" }));
-                            }
-                          }}
-                          style={{ padding: "0.35rem 0.45rem", fontSize: "0.75rem" }}
-                        />
-                        <button
-                          type="button"
-                          className={styles.btn}
-                          style={{ padding: "0.2rem 0.5rem", fontSize: "0.75rem", minWidth: "auto" }}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const value = tagInputs[event.id] ?? "";
-                            onAddTag(event.id, value);
-                            setTagInputs((prev) => ({ ...prev, [event.id]: "" }));
-                          }}
-                          title="Add tag"
-                        >
-                          +
-                        </button>
-                      </div>
-                      <datalist id={`event-tag-suggestions-${event.id}`}>
-                        {tagSuggestions.map((tag) => (
-                          <option key={tag} value={tag} />
-                        ))}
-                      </datalist>
-                    </div>
-                  </td>
-                )}
-                <td data-label="Actions">
-                  <button
-                    type="button"
-                    className={styles.btn}
-                    style={{
-                      padding: "0.3rem 0.6rem",
-                      fontSize: "0.75rem",
-                    }}
-                    onClick={() => onEventClick(event)}
-                  >
-                    View
-                  </button>
-                </td>
-              </tr>
-            ))
-          )}
+          ))}
         </tbody>
       </table>
+
+      <div className="soroscan-events-card-grid" data-testid="events-card-grid">
+        {events.map((event) => (
+          <article
+            key={event.id}
+            className="soroscan-event-card"
+            data-testid="event-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => onEventClick(event)}
+            onKeyDown={(keyEvent) => handleCardKeyDown(keyEvent, event)}
+          >
+            <div className="soroscan-event-card-header">
+              <div className="soroscan-event-card-title">
+                <span className="soroscan-event-card-label">Event Type</span>
+                <span
+                  className={styles.pill}
+                  style={{
+                    borderColor: getEventTypeColor(event.eventType),
+                    backgroundColor: `${getEventTypeColor(event.eventType)}15`,
+                    color: getEventTypeColor(event.eventType),
+                  }}
+                >
+                  {event.eventType}
+                </span>
+              </div>
+              <span className="soroscan-event-card-label">Tap for details</span>
+            </div>
+
+            <div className="soroscan-event-card-grid-inner">
+              <div className="soroscan-event-card-row">
+                <span className="soroscan-event-card-label">Contract</span>
+                <span className="soroscan-event-card-value">
+                  <code>{shortHash(event.contractId)}</code>
+                </span>
+              </div>
+
+              <div className="soroscan-event-card-row">
+                <span className="soroscan-event-card-label">Ledger</span>
+                <span className="soroscan-event-card-value">
+                  {event.ledger}
+                </span>
+              </div>
+
+              <div className="soroscan-event-card-row">
+                <span className="soroscan-event-card-label">Time</span>
+                <span className="soroscan-event-card-value">
+                  {formatDateTime(event.timestamp)}
+                </span>
+              </div>
+
+              <div className="soroscan-event-card-row">
+                <span className="soroscan-event-card-label">Transaction</span>
+                <span className="soroscan-event-card-value">
+                  <code>{shortHash(event.txHash)}</code>
+                </span>
+              </div>
+
+              {showTags && (
+                <div className="soroscan-event-card-row">
+                  <span className="soroscan-event-card-label">Tags</span>
+                  <span className="soroscan-event-card-value">
+                    {(eventTags[event.id] ?? []).join(", ") || "None"}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div className="soroscan-event-card-footer">View details</div>
+          </article>
+        ))}
+      </div>
     </div>
   );
 }

--- a/soroscan-frontend/app/dashboard/components/__tests__/EventTable.test.tsx
+++ b/soroscan-frontend/app/dashboard/components/__tests__/EventTable.test.tsx
@@ -334,7 +334,7 @@ describe("EventTable", () => {
   });
 
   describe("Multi-select (issue #569)", () => {
-    it("renders a checkbox in each event row", () => {
+    it("renders one table checkbox per event row plus the header checkbox", () => {
       render(
         <EventTable
           events={mockEvents}
@@ -345,7 +345,7 @@ describe("EventTable", () => {
       );
 
       const checkboxes = screen.getAllByRole("checkbox");
-      expect(checkboxes).toHaveLength(mockEvents.length * 2 + 1);
+      expect(checkboxes).toHaveLength(mockEvents.length + 1);
     });
 
     it("calls onToggleSelect when a row checkbox is clicked", () => {
@@ -358,7 +358,7 @@ describe("EventTable", () => {
         />,
       );
 
-      const checkbox = screen.getByLabelText("Select event 1");
+      const checkbox = screen.getAllByLabelText("Select event 1")[0];
       fireEvent.click(checkbox);
 
       expect(mockOnToggleSelect).toHaveBeenCalledWith("1");

--- a/soroscan-frontend/app/dashboard/components/__tests__/EventTable.test.tsx
+++ b/soroscan-frontend/app/dashboard/components/__tests__/EventTable.test.tsx
@@ -33,7 +33,7 @@ describe("EventTable", () => {
 
   beforeEach(() => {
     mockOnEventClick.mockClear();
-    // Mock clipboard API
+
     Object.assign(navigator, {
       clipboard: {
         writeText: jest.fn(() => Promise.resolve()),
@@ -48,51 +48,59 @@ describe("EventTable", () => {
   describe("Loading State (issue #595)", () => {
     it("shows skeleton loader while loading", () => {
       const { container } = render(
-        <EventTable events={[]} loading={true} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={[]}
+          loading={true}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
-      // Check that skeleton rows are rendered
       const skeletonRows = container.querySelectorAll("tbody tr");
       expect(skeletonRows.length).toBe(5);
 
-      // Check that skeleton elements exist
       const skeletons = container.querySelectorAll(".skeleton");
       expect(skeletons.length).toBeGreaterThan(0);
     });
 
     it("skeleton matches table structure with 6 columns", () => {
       const { container } = render(
-        <EventTable events={[]} loading={true} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={[]}
+          loading={true}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const firstRow = container.querySelector("tbody tr");
       const cells = firstRow?.querySelectorAll("td");
-      
-      // Should have 6 columns: Contract, Type, Ledger, Time, Transaction, Actions
+
       expect(cells?.length).toBe(6);
     });
 
     it("skeleton has proper styling for each column type", () => {
       const { container } = render(
-        <EventTable events={[]} loading={true} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={[]}
+          loading={true}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const firstRow = container.querySelector("tbody tr");
       const skeletons = firstRow?.querySelectorAll(".skeleton");
-      
-      // Check that different columns have different skeleton widths
+
       expect(skeletons?.length).toBe(6);
-      
-      // Contract column skeleton
       expect(skeletons?.[0]).toHaveStyle({ width: "120px" });
-      
-      // Type column skeleton (pill-shaped)
       expect(skeletons?.[1]).toHaveStyle({ borderRadius: "12px" });
     });
 
     it("does not show skeleton when not loading", () => {
       const { container } = render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const skeletons = container.querySelectorAll(".skeleton");
@@ -101,43 +109,54 @@ describe("EventTable", () => {
 
     it("transitions smoothly from skeleton to content", () => {
       const { container, rerender } = render(
-        <EventTable events={[]} loading={true} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={[]}
+          loading={true}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
-      // Initially shows skeleton
       let skeletons = container.querySelectorAll(".skeleton");
       expect(skeletons.length).toBeGreaterThan(0);
 
-      // Rerender with data
       rerender(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
-      // Skeleton should be gone
       skeletons = container.querySelectorAll(".skeleton");
       expect(skeletons.length).toBe(0);
 
-      // Content should be visible (check for shortened contract ID)
-      expect(screen.getByText(/CCAAA/)).toBeInTheDocument();
+      expect(screen.getAllByText(/CCAAA/).length).toBeGreaterThan(0);
     });
   });
 
   describe("Event Display", () => {
     it("renders events when not loading", () => {
       render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
-      // Check for shortened contract IDs (not full names)
-      expect(screen.getByText(/CCAAA/)).toBeInTheDocument();
-      expect(screen.getByText(/CCBBB/)).toBeInTheDocument();
-      expect(screen.getByText("transfer")).toBeInTheDocument();
-      expect(screen.getByText("swap")).toBeInTheDocument();
+      expect(screen.getAllByText(/CCAAA/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/CCBBB/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText("transfer").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("swap").length).toBeGreaterThan(0);
     });
 
     it("shows empty state when no events and not loading", () => {
       render(
-        <EventTable events={[]} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={[]}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       expect(screen.getByText(/No events found/i)).toBeInTheDocument();
@@ -145,7 +164,11 @@ describe("EventTable", () => {
 
     it("calls onEventClick when View button is clicked", () => {
       render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const viewButtons = screen.getAllByRole("button", { name: /view/i });
@@ -156,7 +179,11 @@ describe("EventTable", () => {
 
     it("copies contract ID to clipboard", async () => {
       render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const copyButtons = screen.getAllByTitle("Copy contract ID");
@@ -169,7 +196,11 @@ describe("EventTable", () => {
 
     it("copies transaction hash to clipboard", async () => {
       render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const copyButtons = screen.getAllByTitle("Copy transaction hash");
@@ -182,8 +213,13 @@ describe("EventTable", () => {
 
     it("shows checkmark after successful copy", async () => {
       jest.useFakeTimers();
+
       render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const copyButtons = screen.getAllByTitle("Copy contract ID");
@@ -193,7 +229,6 @@ describe("EventTable", () => {
         expect(copyButtons[0]).toHaveTextContent("✓");
       });
 
-      // After 2 seconds, should revert to clipboard icon
       await act(async () => {
         jest.advanceTimersByTime(2000);
       });
@@ -201,12 +236,15 @@ describe("EventTable", () => {
       await waitFor(() => {
         expect(copyButtons[0]).toHaveTextContent("📋");
       });
-
     });
 
     it("applies hover effects to event rows", () => {
       const { container } = render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const eventRow = container.querySelector("tbody tr");
@@ -214,10 +252,76 @@ describe("EventTable", () => {
     });
   });
 
+  describe("Responsive Card Grid", () => {
+    it("renders a mobile card grid for events", () => {
+      render(
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
+      );
+
+      expect(screen.getByTestId("events-card-grid")).toBeInTheDocument();
+      expect(screen.getAllByTestId("event-card")).toHaveLength(2);
+    });
+
+    it("shows event information in mobile cards", () => {
+      render(
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("event-card");
+
+      expect(cards[0]).toHaveTextContent("transfer");
+      expect(cards[0]).toHaveTextContent("CCAAA123");
+      expect(cards[0]).toHaveTextContent("1000");
+      expect(cards[0]).toHaveTextContent("abc123");
+    });
+
+    it("opens event details when a mobile card is clicked", () => {
+      render(
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("event-card");
+      fireEvent.click(cards[0]);
+
+      expect(mockOnEventClick).toHaveBeenCalledWith(mockEvents[0]);
+    });
+
+    it("opens event details from keyboard on a mobile card", () => {
+      render(
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
+      );
+
+      const cards = screen.getAllByTestId("event-card");
+      fireEvent.keyDown(cards[0], { key: "Enter" });
+
+      expect(mockOnEventClick).toHaveBeenCalledWith(mockEvents[0]);
+    });
+  });
+
   describe("Accessibility", () => {
     it("has proper table structure", () => {
       render(
-        <EventTable events={mockEvents} loading={false} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={mockEvents}
+          loading={false}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const table = screen.getByRole("table");
@@ -229,16 +333,17 @@ describe("EventTable", () => {
 
     it("skeleton rows have unique keys", () => {
       const { container } = render(
-        <EventTable events={[]} loading={true} onEventClick={mockOnEventClick} />
+        <EventTable
+          events={[]}
+          loading={true}
+          onEventClick={mockOnEventClick}
+        />,
       );
 
       const rows = container.querySelectorAll("tbody tr");
-      
-      // Check that we have 5 skeleton rows
+
       expect(rows.length).toBe(5);
-      
-      // React keys are used internally and don't appear in DOM
-      // Just verify all rows are rendered
+
       rows.forEach((row) => {
         expect(row).toBeInTheDocument();
       });


### PR DESCRIPTION
## Summary

Implements a responsive mobile card grid view for events.

On smaller screens, events are displayed as cards instead of the desktop table layout to improve usability and readability.

Closes #604.

## Changes Made

- Added responsive mobile card grid layout for `EventTable`
- Displayed event information inside mobile cards:
  - Contract
  - Event Type
  - Ledger
  - Timestamp
  - Transaction Hash
- Added interactive mobile card actions for viewing event details
- Added keyboard accessibility support for mobile cards
- Updated existing `EventTable` tests
- Added dedicated responsive layout tests

## Acceptance Criteria Coverage

✅ Grid layout on mobile  
✅ Cards show event info  
✅ Click for details  
✅ Tests verify layout

## Testing

```bash
npm run lint
npm test -- EventTable.test.tsx event-table-responsive.test.tsx --runInBand