### PR TITLE
Feat: add endpoint for event type statistics

### DIFF
--- a/django-backend/soroscan/ingest/tests/test_event_type_statistics.py
+++ b/django-backend/soroscan/ingest/tests/test_event_type_statistics.py
@@ -1,0 +1,87 @@
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from soroscan.ingest.tests.factories import (
+    ContractEventFactory,
+    TrackedContractFactory,
+)
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+
+
+@pytest.mark.django_db
+class TestEventTypeStatisticsEndpoint:
+    def test_endpoint_returns_event_type_distribution_for_contract(self, api_client):
+        contract = TrackedContractFactory()
+
+        ContractEventFactory(contract=contract, event_type="transfer")
+        ContractEventFactory(contract=contract, event_type="transfer")
+        ContractEventFactory(contract=contract, event_type="swap")
+
+        url = reverse("event-type-statistics")
+        response = api_client.get(url, {"contract_id": contract.contract_id})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["contract_id"] == contract.contract_id
+        assert response.data["total_events"] == 3
+
+        counts = {
+            item["event_type"]: item["count"]
+            for item in response.data["event_types"]
+        }
+
+        assert counts["transfer"] == 2
+        assert counts["swap"] == 1
+
+    def test_endpoint_filters_by_contract(self, api_client):
+        contract = TrackedContractFactory()
+        other_contract = TrackedContractFactory()
+
+        ContractEventFactory(contract=contract, event_type="transfer")
+        ContractEventFactory(contract=contract, event_type="transfer")
+        ContractEventFactory(contract=other_contract, event_type="mint")
+
+        url = reverse("event-type-statistics")
+        response = api_client.get(url, {"contract_id": contract.contract_id})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["total_events"] == 2
+
+        returned_contract_ids = {
+            item["contract_id"]
+            for item in response.data["event_types"]
+        }
+
+        assert returned_contract_ids == {contract.contract_id}
+
+    def test_endpoint_returns_global_distribution_without_contract_filter(self, api_client):
+        contract = TrackedContractFactory()
+        other_contract = TrackedContractFactory()
+
+        ContractEventFactory(contract=contract, event_type="transfer")
+        ContractEventFactory(contract=other_contract, event_type="mint")
+
+        url = reverse("event-type-statistics")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["contract_id"] is None
+        assert response.data["total_events"] == 2
+        assert len(response.data["event_types"]) == 2
+
+    def test_endpoint_returns_404_for_unknown_contract(self, api_client):
+        url = reverse("event-type-statistics")
+        response = api_client.get(url, {"contract_id": "C" + "Z" * 55})
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/django-backend/soroscan/ingest/urls.py
+++ b/django-backend/soroscan/ingest/urls.py
@@ -15,6 +15,7 @@ from .views import (
     compliance_export_view,
     contract_event_explorer_view,
     contract_event_types_view,
+    event_type_statistics_view,
     contract_identity_view,
     organization_cost_breakdown_view,
     WebhookSubscriptionViewSet,
@@ -44,10 +45,16 @@ urlpatterns = [
         contract_event_explorer_view,
         name="contract-event-explorer",
     ),
+   path(
+    "contracts/<str:contract_id>/event-types/",
+    contract_event_types_view,
+    name="contract-event-types",
+    ),
+
     path(
-        "contracts/<str:contract_id>/event-types/",
-        contract_event_types_view,
-        name="contract-event-types",
+        "events/type-statistics/",
+        event_type_statistics_view,
+        name="event-type-statistics",
     ),
     path(
         "contracts/<str:contract_id>/deployments/",
@@ -63,6 +70,7 @@ urlpatterns = [
     path("", include(router.urls)),
     path("record/", record_event_view, name="record-event"),
     path("health/", health_check, name="health-check"),
+    path("events/type-statistics/", event_type_statistics_view, name="event-type-statistics"),
     path("events/restore-archive/", restore_archived_events, name="restore-archive"),
     path("audit-trail/", audit_trail_view, name="audit-trail"),
     path("admin/ingest-errors/", admin_ingest_errors_view, name="admin-ingest-errors"),

--- a/django-backend/soroscan/ingest/views.py
+++ b/django-backend/soroscan/ingest/views.py
@@ -1091,6 +1091,79 @@ def contract_event_types_view(request, contract_id: str):
 @extend_schema(
     parameters=[
         inline_serializer(
+            name="EventTypeStatisticsParams",
+            fields={
+                "contract_id": serializers.CharField(required=False),
+            },
+        )
+    ],
+    responses=inline_serializer(
+        name="EventTypeStatisticsResponse",
+        fields={
+            "contract_id": serializers.CharField(allow_null=True),
+            "total_events": serializers.IntegerField(),
+            "event_types": serializers.JSONField(),
+        },
+    ),
+)
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def event_type_statistics_view(request):
+    """Return event type distribution globally or for a specific contract."""
+    contract_id = request.query_params.get("contract_id")
+
+    contract = None
+    if contract_id:
+        contract = get_cached_contract(contract_id)
+        if not contract:
+            from django.http import Http404
+            raise Http404
+
+    cache_key = stable_cache_key(
+        "event_type_statistics",
+        {"contract_id": contract_id or "all"},
+    )
+
+    def _build():
+        events = ContractEvent.objects.select_related("contract").all()
+
+        if contract:
+            events = events.filter(contract=contract)
+
+        total_events = events.count()
+
+        event_types = list(
+            events.values("contract__contract_id", "event_type")
+            .annotate(
+                count=Count("id"),
+                first_seen=Min("timestamp"),
+                last_seen=Max("timestamp"),
+            )
+            .order_by("contract__contract_id", "-count", "event_type")
+        )
+
+        return {
+            "contract_id": contract_id if contract_id else None,
+            "total_events": total_events,
+            "event_types": [
+                {
+                    "contract_id": item["contract__contract_id"],
+                    "event_type": item["event_type"],
+                    "count": item["count"],
+                    "first_seen": item["first_seen"],
+                    "last_seen": item["last_seen"],
+                }
+                for item in event_types
+            ],
+        }
+
+    payload = get_or_set_json(cache_key, query_cache_ttl(), _build)
+    return Response(payload)
+
+
+@extend_schema(
+    parameters=[
+        inline_serializer(
             name="RestoreArchiveParams",
             fields={"batch_id": serializers.IntegerField()},
         )


### PR DESCRIPTION
## Summary

Adds a REST endpoint for event type statistics.

Closes #585

## Changes Made

- Added an event type statistics endpoint
- Added support for querying statistics by `contract_id`
- Aggregated event type counts per contract
- Included total event count and event type distribution in the response
- Added tests covering:
  - event type distribution counts
  - contract filtering
  - global statistics without a contract filter
  - unknown contract handling

## Testing

```bash
python -m pytest soroscan/ingest/tests/test_event_type_statistics.py -v
