### PR TITLE
Feat: add uptime fields to health endpoint

### DIFF
--- a/django-backend/soroscan/health.py
+++ b/django-backend/soroscan/health.py
@@ -1,6 +1,8 @@
 """
 Health check endpoints for Kubernetes liveness/readiness probes.
 """
+import time
+
 from django.core.cache import cache
 from django.db import connection
 from rest_framework.decorators import api_view, permission_classes
@@ -8,11 +10,38 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 
+PROCESS_START_TIME = time.monotonic()
+
+
+def format_uptime(seconds: int) -> str:
+    """Format uptime seconds as DH:M:S."""
+    days, remainder = divmod(seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    return f"{days}D:{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def get_uptime_payload() -> dict:
+    """Return machine-readable and human-readable uptime values."""
+    uptime_seconds = max(0, int(time.monotonic() - PROCESS_START_TIME))
+
+    return {
+        "uptime_seconds": uptime_seconds,
+        "uptime": format_uptime(uptime_seconds),
+    }
+
+
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health_view(request):
     """Liveness probe - app is running."""
-    return Response({"status": "ok"})
+    return Response(
+        {
+            "status": "ok",
+            **get_uptime_payload(),
+        }
+    )
 
 
 @api_view(["GET"])

--- a/django-backend/soroscan/ingest/tests/test_health.py
+++ b/django-backend/soroscan/ingest/tests/test_health.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from django.conf import settings
 from django.core.cache import cache
@@ -5,6 +7,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from soroscan.health import format_uptime
 
 
 @pytest.fixture
@@ -14,13 +17,36 @@ def api_client():
 
 @pytest.mark.django_db
 class TestHealthView:
-    def test_health_returns_ok(self, api_client):
+    def test_health_returns_ok_with_uptime(self, api_client):
         url = reverse("health")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {"status": "ok"}
+        assert response.data["status"] == "ok"
+        assert "uptime_seconds" in response.data
+        assert "uptime" in response.data
+        assert isinstance(response.data["uptime_seconds"], int)
+        assert response.data["uptime_seconds"] >= 0
+        assert isinstance(response.data["uptime"], str)
         assert response["X-SoroScan-Version"] == settings.SOFTWARE_VERSION
+
+    def test_health_uptime_is_human_readable(self):
+        assert format_uptime(0) == "0D:00:00:00"
+        assert format_uptime(59) == "0D:00:00:59"
+        assert format_uptime(60) == "0D:00:01:00"
+        assert format_uptime(3600) == "0D:01:00:00"
+        assert format_uptime(90061) == "1D:01:01:01"
+
+    def test_health_uptime_counter_increases_across_requests(self, api_client):
+        url = reverse("health")
+
+        first_response = api_client.get(url)
+        time.sleep(1.1)
+        second_response = api_client.get(url)
+
+        assert first_response.status_code == status.HTTP_200_OK
+        assert second_response.status_code == status.HTTP_200_OK
+        assert second_response.data["uptime_seconds"] >= first_response.data["uptime_seconds"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Adds process uptime information to the health endpoint.

Closes #473

## Changes Made

- Added Django process start time tracking
- Exposed `uptime_seconds` in the health response
- Added human-readable uptime format as `uptime`
- Added tests to verify:
  - uptime fields are present
  - uptime format is correct
  - uptime counter remains accurate across requests

## Testing

```bash
python -m pytest soroscan/ingest/tests/test_health.py -v