### PR TITLE
feat: add FullPageLoader component with loading overlay functionality

### DIFF
--- a/soroscan-frontend/__tests__/full-page-loader.test.tsx
+++ b/soroscan-frontend/__tests__/full-page-loader.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { FullPageLoader } from "../components/ui/FullPageLoader";
+import "@testing-library/jest-dom";
+
+describe("FullPageLoader", () => {
+  it("renders a centered overlay when loading", () => {
+    render(<FullPageLoader isLoading={true} message="Please wait" />);
+
+    const overlay = screen.getByRole("status");
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveClass("fixed inset-0");
+    expect(screen.getAllByText("Please wait").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not render when not loading", () => {
+    render(<FullPageLoader isLoading={false} />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/soroscan-frontend/components/ui/FullPageLoader.tsx
+++ b/soroscan-frontend/components/ui/FullPageLoader.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+
+interface FullPageLoaderProps {
+  isLoading: boolean;
+  message?: string;
+}
+
+export function FullPageLoader({ isLoading, message = "Loading..." }: FullPageLoaderProps) {
+  if (!isLoading) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-0 z-[9999] grid place-items-center bg-terminal-black/90 text-terminal-green"
+    >
+      <div className="flex flex-col items-center justify-center gap-4 rounded border border-terminal-green/30 bg-terminal-black/95 p-6 shadow-glow-green/30">
+        <div className="h-16 w-16 rounded-full border-4 border-terminal-green/10 border-t-terminal-green animate-spin" />
+        <span className="text-sm font-terminal-mono text-terminal-green/80">{message}</span>
+      </div>
+      <span className="sr-only">{message}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Added reusable FullPageLoader component for full-page async loading states
Overlay is centered, blocks interactions, and includes an animated spinner
Added tests verifying display when loading and hidden state otherwise

Closes #608 