### PR TITLE
Add Celery worker health endpoint at /api/health/workers/ with tests

### DIFF
--- a/django-backend/soroscan/health.py
+++ b/django-backend/soroscan/health.py
@@ -7,6 +7,12 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+from celery.exceptions import TimeoutError
+
+from soroscan.celery import app
+
+WORKER_HEALTH_TIMEOUT_SECONDS = 2
+
 
 @api_view(["GET"])
 @permission_classes([AllowAny])
@@ -38,3 +44,27 @@ def readiness_view(request):
         return Response({"status": "not_ready", "errors": errors}, status=503)
 
     return Response({"status": "ready"})
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def worker_health_view(request):
+    """Worker health probe - checks Celery workers are responding."""
+    try:
+        inspector = app.control.inspect(timeout=WORKER_HEALTH_TIMEOUT_SECONDS)
+        worker_status = inspector.ping()
+
+        if not worker_status:
+            raise Exception("no worker responded")
+
+        return Response({"status": "healthy", "workers": worker_status})
+    except TimeoutError:
+        return Response(
+            {"status": "unhealthy", "error": "worker ping timeout"},
+            status=503,
+        )
+    except Exception as exc:
+        return Response(
+            {"status": "unhealthy", "error": str(exc)},
+            status=503,
+        )

--- a/django-backend/soroscan/ingest/tests/test_health.py
+++ b/django-backend/soroscan/ingest/tests/test_health.py
@@ -62,3 +62,42 @@ class TestReadinessView:
         assert response.data["status"] == "not_ready"
         assert any("redis" in e for e in response.data["errors"])
         assert response["X-SoroScan-Version"] == settings.SOFTWARE_VERSION
+
+
+@pytest.mark.django_db
+class TestWorkerHealthView:
+    def test_worker_health_returns_200_when_worker_responds(self, api_client, monkeypatch):
+        class DummyInspect:
+            def ping(self):
+                return {"worker1@hostname": {"ok": "pong"}}
+
+        monkeypatch.setattr(
+            "soroscan.health.app.control.inspect",
+            lambda timeout=None: DummyInspect(),
+        )
+
+        url = reverse("worker-health")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "healthy"
+        assert response.data["workers"] == {"worker1@hostname": {"ok": "pong"}}
+        assert response["X-SoroScan-Version"] == settings.SOFTWARE_VERSION
+
+    def test_worker_health_returns_503_when_workers_unresponsive(self, api_client, monkeypatch):
+        class DummyInspect:
+            def ping(self):
+                return {}
+
+        monkeypatch.setattr(
+            "soroscan.health.app.control.inspect",
+            lambda timeout=None: DummyInspect(),
+        )
+
+        url = reverse("worker-health")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.data["status"] == "unhealthy"
+        assert "no worker responded" in response.data["error"]
+        assert response["X-SoroScan-Version"] == settings.SOFTWARE_VERSION

--- a/django-backend/soroscan/urls.py
+++ b/django-backend/soroscan/urls.py
@@ -15,7 +15,7 @@ from rest_framework_simplejwt.views import (
 )
 
 from soroscan.graphql_views import ThrottledGraphQLView
-from soroscan.health import health_view, readiness_view
+from soroscan.health import health_view, readiness_view, worker_health_view
 from soroscan.meta_views import db_pool_stats_view
 from soroscan.ingest.views import (
     audit_trail_view,
@@ -40,6 +40,7 @@ urlpatterns = [
 
     path("health/", health_view, name="health"),
     path("ready/", readiness_view, name="readiness"),
+    path("api/health/workers/", worker_health_view, name="worker-health"),
 
     path("admin/", admin.site.urls),
     path("api/audit-trail/", audit_trail_view, name="audit-trail"),

--- a/django-backend/soroscan/urls_test.py
+++ b/django-backend/soroscan/urls_test.py
@@ -9,7 +9,7 @@ from django.contrib import admin
 from django.http import JsonResponse
 from django.urls import include, path
 
-from soroscan.health import health_view, readiness_view
+from soroscan.health import health_view, readiness_view, worker_health_view
 from soroscan.meta_views import db_pool_stats_view
 from soroscan.ingest.views import (
     contract_status,
@@ -39,6 +39,7 @@ urlpatterns = [
     path("api/contracts/status/", contract_status, name="contract-status"),
     path("api/analytics/rate-limits/", rate_limit_analytics_view, name="rate-limit-analytics"),
     path("api/meta/db-pool/", db_pool_stats_view, name="db-pool-stats"),
+    path("api/health/workers/", worker_health_view, name="worker-health"),
     path("api/dev/summary/", dev_summary_view, name="dev-summary"),
     path(
         "api/webhooks/deliveries/batch-status/",


### PR DESCRIPTION
Added a dedicated Celery worker health endpoint at api/health/workers/
Uses app.control.inspect().ping() to verify worker responsiveness
Returns 200 OK when workers respond and 503 Service Unavailable otherwise
Includes backend URL routing and endpoint tests covering success/failure cases

Closes #471 